### PR TITLE
fix(migrate): preserve repo directory inode during migration

### DIFF
--- a/git-wt
+++ b/git-wt
@@ -601,7 +601,9 @@ migrate)
 			rm -rf "$NEW_STRUCTURE"
 		fi
 		if [[ -d $TEMP_BACKUP ]]; then
-			rm -rf "$TEMP_BACKUP"
+			# Restore original contents from backup into REPO_ROOT
+			(shopt -s dotglob && mv "$TEMP_BACKUP"/* "$REPO_ROOT"/ 2>/dev/null) || true
+			rmdir "$TEMP_BACKUP" 2>/dev/null || rm -rf "$TEMP_BACKUP"
 		fi
 		exit $exit_code
 	}
@@ -712,12 +714,16 @@ migrate)
 	echo "Working directory state restored (all files preserved)"
 
 	# Success - now replace the old repo with the new structure
+	# Move contents (not the directory itself) to preserve REPO_ROOT's inode,
+	# so any shell whose cwd is REPO_ROOT doesn't lose its working directory.
 	echo ""
 	echo "Finalizing migration..."
 
 	cd "$PARENT_DIR"
-	mv "$REPO_ROOT" "$TEMP_BACKUP"
-	mv "$NEW_STRUCTURE" "$REPO_ROOT"
+	mkdir -p "$TEMP_BACKUP"
+	(shopt -s dotglob && mv "$REPO_ROOT"/* "$TEMP_BACKUP"/)
+	(shopt -s dotglob && mv "$NEW_STRUCTURE"/* "$REPO_ROOT"/)
+	rmdir "$NEW_STRUCTURE"
 
 	echo "Cleaning up..."
 	rm -rf "$TEMP_BACKUP"


### PR DESCRIPTION
## Summary

After `git wt migrate`, the user's shell reports `getcwd: cannot access parent directories: No such file or directory` because the migration swapped the repo directory via `mv`, replacing its inode. Any shell whose cwd was the repo directory loses its working directory reference.

**Fix:** Move directory *contents* instead of the directories themselves during the swap phase, preserving the original `REPO_ROOT` inode.

## Changes

- **Swap phase**: Replace `mv "$REPO_ROOT" "$TEMP_BACKUP"` / `mv "$NEW_STRUCTURE" "$REPO_ROOT"` with content-level moves using `shopt -s dotglob`
- **Cleanup handler**: Restore contents back into `REPO_ROOT` on interrupt (instead of just deleting the backup)
- **Test**: Assert the directory inode is unchanged after migration (portable across macOS and Linux)

## Test plan

- [x] All 73 existing tests pass
- [x] New inode preservation test passes
- [x] shellcheck clean