### PR TITLE
fix: show relative worktree paths in interactive picker

### DIFF
--- a/git-wt
+++ b/git-wt
@@ -205,13 +205,14 @@ get_worktree_list() {
 
 format_worktree_for_display() {
 	# Convert "path:branch:head" format to display format for fzf
-	# Input: /path/to/worktree:branch-name:abc1234
+	# Input: /path/to/worktree:branch-name:abc1234 <bare-root>
 	# Output: workspace [branch-name]\t\e[2m~/path/to/worktree\e[0m
 	local entry=$1
+	local bare_root=$2
 	local wt_path="${entry%%:*}"
 	local rest="${entry#*:}"
 	local branch="${rest%%:*}"
-	local workspace="${wt_path##*/}"
+	local workspace="${wt_path#"$bare_root"/}"
 	local display_path="${wt_path/#$HOME/\~}"
 
 	if [[ -n $branch && $branch != "(detached)" ]]; then
@@ -285,11 +286,12 @@ get_default_branch() {
 
 build_worktree_display_list() {
 	# Build newline-separated display list of worktrees for fzf
-	# Output: /path/to/worktree abc1234 [branch-name]
-	local result="" entry display_line
+	# Output: workspace [branch-name]\t~/path/to/worktree
+	local bare_root result="" entry display_line
+	bare_root=$(get_bare_root)
 	while IFS= read -r entry; do
 		if [[ -n $entry ]]; then
-			display_line=$(format_worktree_for_display "$entry")
+			display_line=$(format_worktree_for_display "$entry" "$bare_root")
 			if [[ -n $result ]]; then
 				result="${result}"$'\n'"${display_line}"
 			else


### PR DESCRIPTION
## Summary

- Fix `format_worktree_for_display()` to show relative paths (e.g. `feature/my-thing`) instead of just the basename (`my-thing`) in the interactive fzf picker
- Pass `bare_root` from `build_worktree_display_list()` so workspace name is computed as a relative path from bare root
- Add 4 tests covering interactive round-trip and display format verification for slash-containing worktrees

## Before/After

For worktree at `<bare-root>/feature/my-thing`:

| | Display |
|---|---|
| **Before** | `my-thing [feature/my-thing]  ~/repo/feature/my-thing` |
| **After** | `feature/my-thing [feature/my-thing]  ~/repo/feature/my-thing` |

Simple worktrees like `main` are unchanged.

## Test plan

- [x] `shellcheck git-wt` passes
- [x] All 104 bats tests pass (4 new)
- [x] `nix fmt` -- no formatting changes
- [x] Pre-commit and pre-push hooks pass

Closes #11