### PR TITLE
feat: Migrate hook capability from https://github.com/k1LoW/git-wt

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,28 @@ git wt list --porcelain
 git wt update # or: git wt u
 ```
 
+## Hooks
+
+Run shell commands when worktrees are created or removed, configured through Git
+config so they can be scoped per-repository or globally with `--global`. Useful
+for expensive per-worktree setup, such as copying a generated
+`compile_commands.json` from your main checkout into every new worktree.
+
+```bash
+# Runs after `git wt add`, in the new worktree directory
+git config --add wt.addhook 'cp ../main/compile_commands.json .'
+
+# Runs before `git wt remove`, in the worktree being removed
+git config --add wt.removehook './scripts/cleanup.sh'
+```
+
+- Each hook runs with `sh -c` in the worktree directory
+- Repeated `--add` registers multiple hooks; they run in order and stop on the first failure
+- Hook output goes to stderr, keeping the path that `git wt add` prints on stdout clean
+- A failing `wt.removehook` aborts the removal; a failing `wt.addhook` exits non-zero without printing the path
+- `wt.removehook` is skipped for the current worktree, locked worktrees, and stale or prunable entries
+- `DEBUG=1` echoes hooks instead of running them
+
 ## Commands
 
 | Command             | Description                                                |

--- a/README.md
+++ b/README.md
@@ -225,25 +225,41 @@ git wt update # or: git wt u
 
 ## Hooks
 
-Run shell commands when worktrees are created or removed, configured through Git
-config so they can be scoped per-repository or globally with `--global`. Useful
-for expensive per-worktree setup, such as copying a generated
-`compile_commands.json` from your main checkout into every new worktree.
+Run shell commands around worktree creation and removal. Hooks are configured through Git config, so they can be scoped per repository or globally with `--global`.
 
 ```bash
-# Runs after `git wt add`, in the new worktree directory
-git config --add wt.addhook 'cp ../main/compile_commands.json .'
+# Validate the repository before creating a worktree
+git config --add wt.beforeadd './scripts/check-worktree.sh'
 
-# Runs before `git wt remove`, in the worktree being removed
-git config --add wt.removehook './scripts/cleanup.sh'
+# Copy generated files into each new worktree
+git config --add wt.afteradd 'cp ../main/compile_commands.json .'
+
+# Clean up files while the worktree still exists
+git config --add wt.beforeremove './scripts/cleanup-worktree.sh'
+
+# Notify another tool after removal is complete
+git config --add wt.afterremove 'workspace-registry remove "$GIT_WT_PATH"'
 ```
 
-- Each hook runs with `sh -c` in the worktree directory
-- Repeated `--add` registers multiple hooks; they run in order and stop on the first failure
-- Hook output goes to stderr, keeping the path that `git wt add` prints on stdout clean
-- A failing `wt.removehook` aborts the removal; a failing `wt.addhook` exits non-zero without printing the path
-- `wt.removehook` is skipped for the current worktree, locked worktrees, and stale or prunable entries
-- `DEBUG=1` echoes hooks instead of running them
+| Hook              | When it runs                                                               | Working directory      | Failure behavior                                        |
+| ----------------- | -------------------------------------------------------------------------- | ---------------------- | ------------------------------------------------------- |
+| `wt.beforeadd`    | After add arguments and fetching are complete, immediately before creation | Bare repository root   | Prevents worktree creation                              |
+| `wt.afteradd`     | After creation and upstream configuration                                  | New worktree           | Leaves the worktree in place and exits non-zero         |
+| `wt.beforeremove` | Immediately before removal                                                 | Worktree being removed | Preserves the worktree and exits non-zero               |
+| `wt.afterremove`  | After worktree and branch cleanup                                          | Bare repository root   | Removal remains complete and the command exits non-zero |
+
+Every hook receives the lifecycle context through environment variables:
+
+- `GIT_WT_EVENT`: `beforeadd`, `afteradd`, `beforeremove`, or `afterremove`
+- `GIT_WT_PATH`: absolute worktree path
+- `GIT_WT_BRANCH`: branch name, or empty for detached or unresolved cases
+- `GIT_WT_BARE_ROOT`: absolute bare repository root
+
+Each configured value runs with `sh -c`. Repeated `git config --add` values run in order and stop at the first failure for that event; multiline values are supported. Hook output goes to stderr so successful `git wt add` output remains machine-readable.
+
+Before-hooks are not transactional: the subsequent Git operation can still fail after a hook succeeds, so side effects should be idempotent. After-hook failures cannot roll back an operation that already completed. Removing the current worktree or a locked worktree is rejected before any hook runs; for stale, missing, or prunable worktrees the removal proceeds with the hooks skipped. `DEBUG=1` echoes hooks instead of running them.
+
+Hooks apply to `git wt add` and `git wt remove`; the initial worktree created by `git wt clone` does not trigger add hooks.
 
 ## Commands
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,22 +86,41 @@ repo/
 
 ## Hooks
 
-Run shell commands when worktrees are created or removed, configured through Git config so they can be scoped per-repository or globally with `--global`. Useful for expensive per-worktree setup, such as copying a generated `compile_commands.json` from your main checkout into every new worktree.
+Run shell commands around worktree creation and removal. Hooks are configured through Git config, so they can be scoped per repository or globally with `--global`.
 
 ```bash
-# Runs after `git wt add`, in the new worktree directory
-git config --add wt.addhook 'cp ../main/compile_commands.json .'
+# Validate the repository before creating a worktree
+git config --add wt.beforeadd './scripts/check-worktree.sh'
 
-# Runs before `git wt remove`, in the worktree being removed
-git config --add wt.removehook './scripts/cleanup.sh'
+# Copy generated files into each new worktree
+git config --add wt.afteradd 'cp ../main/compile_commands.json .'
+
+# Clean up files while the worktree still exists
+git config --add wt.beforeremove './scripts/cleanup-worktree.sh'
+
+# Notify another tool after removal is complete
+git config --add wt.afterremove 'workspace-registry remove "$GIT_WT_PATH"'
 ```
 
-- Each hook runs with `sh -c` in the worktree directory
-- Repeated `--add` registers multiple hooks; they run in order and stop on the first failure
-- Hook output goes to stderr, keeping the path that `git wt add` prints on stdout clean
-- A failing `wt.removehook` aborts the removal; a failing `wt.addhook` exits non-zero without printing the path
-- `wt.removehook` is skipped for the current worktree, locked worktrees, and stale or prunable entries
-- `DEBUG=1` echoes hooks instead of running them
+| Hook              | When it runs                                                               | Working directory      | Failure behavior                                        |
+| ----------------- | -------------------------------------------------------------------------- | ---------------------- | ------------------------------------------------------- |
+| `wt.beforeadd`    | After add arguments and fetching are complete, immediately before creation | Bare repository root   | Prevents worktree creation                              |
+| `wt.afteradd`     | After creation and upstream configuration                                  | New worktree           | Leaves the worktree in place and exits non-zero         |
+| `wt.beforeremove` | Immediately before removal                                                 | Worktree being removed | Preserves the worktree and exits non-zero               |
+| `wt.afterremove`  | After worktree and branch cleanup                                          | Bare repository root   | Removal remains complete and the command exits non-zero |
+
+Every hook receives the lifecycle context through environment variables:
+
+- `GIT_WT_EVENT`: `beforeadd`, `afteradd`, `beforeremove`, or `afterremove`
+- `GIT_WT_PATH`: absolute worktree path
+- `GIT_WT_BRANCH`: branch name, or empty for detached or unresolved cases
+- `GIT_WT_BARE_ROOT`: absolute bare repository root
+
+Each configured value runs with `sh -c`. Repeated `git config --add` values run in order and stop at the first failure for that event; multiline values are supported. Hook output goes to stderr so successful `git wt add` output remains machine-readable.
+
+Before-hooks are not transactional: the subsequent Git operation can still fail after a hook succeeds, so side effects should be idempotent. After-hook failures cannot roll back an operation that already completed. Removing the current worktree or a locked worktree is rejected before any hook runs; for stale, missing, or prunable worktrees the removal proceeds with the hooks skipped. `DEBUG=1` echoes hooks instead of running them.
+
+Hooks apply to `git wt add` and `git wt remove`; the initial worktree created by `git wt clone` does not trigger add hooks.
 
 ## Commands
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,6 +84,25 @@ repo/
 └── main/           # Worktree for default branch
 ```
 
+## Hooks
+
+Run shell commands when worktrees are created or removed, configured through Git config so they can be scoped per-repository or globally with `--global`. Useful for expensive per-worktree setup, such as copying a generated `compile_commands.json` from your main checkout into every new worktree.
+
+```bash
+# Runs after `git wt add`, in the new worktree directory
+git config --add wt.addhook 'cp ../main/compile_commands.json .'
+
+# Runs before `git wt remove`, in the worktree being removed
+git config --add wt.removehook './scripts/cleanup.sh'
+```
+
+- Each hook runs with `sh -c` in the worktree directory
+- Repeated `--add` registers multiple hooks; they run in order and stop on the first failure
+- Hook output goes to stderr, keeping the path that `git wt add` prints on stdout clean
+- A failing `wt.removehook` aborts the removal; a failing `wt.addhook` exits non-zero without printing the path
+- `wt.removehook` is skipped for the current worktree, locked worktrees, and stale or prunable entries
+- `DEBUG=1` echoes hooks instead of running them
+
 ## Commands
 
 | Command             | Description                                                |

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/ahmedelgabri/git-wt/internal/git"
+	"github.com/ahmedelgabri/git-wt/internal/hook"
 	"github.com/ahmedelgabri/git-wt/internal/picker"
 	"github.com/ahmedelgabri/git-wt/internal/ui"
 	"github.com/ahmedelgabri/git-wt/internal/worktree"
@@ -63,28 +64,35 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to change to bare root: %w", err)
 	}
 
+	var createdPath string
+
 	interactive := len(args) == 0 && !cmd.Flags().Changed("branch") && !cmd.Flags().Changed("force-branch")
 	if interactive {
-		createdPath, err := runAddInteractive()
+		createdPath, err = runAddInteractive()
 		if err != nil {
 			return err
 		}
-		return printCreatedWorktreePath(createdPath)
-	}
+	} else {
+		remote := worktree.DefaultRemote()
+		if remote != "" {
+			if err := ui.SpinWithOutputRawContext(fmt.Sprintf("Fetching from %s", remote), func(ctx context.Context, w io.Writer) error {
+				return git.RunToContext(ctx, w, "fetch", remote, "--prune")
+			}); err != nil {
+				return err
+			}
+		}
 
-	remote := worktree.DefaultRemote()
-	if remote != "" {
-		if err := ui.SpinWithOutputRawContext(fmt.Sprintf("Fetching from %s", remote), func(ctx context.Context, w io.Writer) error {
-			return git.RunToContext(ctx, w, "fetch", remote, "--prune")
-		}); err != nil {
+		createdPath, err = runAddDirect(cmd, args, remote)
+		if err != nil {
 			return err
 		}
 	}
 
-	// Non-interactive: build git args from parsed flags.
-	createdPath, err := runAddDirect(cmd, args, remote)
-	if err != nil {
-		return err
+	if createdPath != "" {
+		if err := runAddHooks(createdPath); err != nil {
+			fmt.Println(createdPath)
+			return err
+		}
 	}
 	return printCreatedWorktreePath(createdPath)
 }
@@ -245,6 +253,21 @@ func runAddDirect(cmd *cobra.Command, args []string, remote string) (string, err
 func splitRemoteBranchRef(remoteRef string) (remote string, branch string) {
 	remote, branch, _ = strings.Cut(remoteRef, "/")
 	return remote, branch
+}
+
+func runAddHooks(wtPath string) error {
+	hooks, err := hook.LoadConfig("wt.hook")
+	if err != nil {
+		return err
+	}
+	if len(hooks) == 0 {
+		return nil
+	}
+	absPath, err := filepath.Abs(wtPath)
+	if err != nil {
+		return err
+	}
+	return hook.Run(context.Background(), hooks, absPath, os.Stderr)
 }
 
 func printCreatedWorktreePath(path string) error {

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -90,7 +90,10 @@ func runAdd(cmd *cobra.Command, args []string) error {
 
 	if createdPath != "" {
 		if err := runAddHooks(createdPath); err != nil {
-			fmt.Println(createdPath)
+			// Keep stdout for the success path only; hint goes to stderr.
+			if abs, pErr := resolveCreatedPath(createdPath); pErr == nil {
+				fmt.Fprintf(os.Stderr, "Worktree was created at %s, but hook failed\n", abs)
+			}
 			return err
 		}
 	}
@@ -256,7 +259,7 @@ func splitRemoteBranchRef(remoteRef string) (remote string, branch string) {
 }
 
 func runAddHooks(wtPath string) error {
-	hooks, err := hook.LoadConfig("wt.hook")
+	hooks, err := hook.LoadConfig("wt.addhook")
 	if err != nil {
 		return err
 	}
@@ -270,16 +273,24 @@ func runAddHooks(wtPath string) error {
 	return hook.Run(context.Background(), hooks, absPath, os.Stderr)
 }
 
+func resolveCreatedPath(path string) (string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	if resolvedPath, err := filepath.EvalSymlinks(absPath); err == nil {
+		absPath = resolvedPath
+	}
+	return absPath, nil
+}
+
 func printCreatedWorktreePath(path string) error {
 	if path == "" {
 		return nil
 	}
-	absPath, err := filepath.Abs(path)
+	absPath, err := resolveCreatedPath(path)
 	if err != nil {
 		return err
-	}
-	if resolvedPath, err := filepath.EvalSymlinks(absPath); err == nil {
-		absPath = resolvedPath
 	}
 	fmt.Println(absPath)
 	return nil

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -88,15 +88,6 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if createdPath != "" {
-		if err := runAddHooks(createdPath); err != nil {
-			// Keep stdout for the success path only; hint goes to stderr.
-			if abs, pErr := resolveCreatedPath(createdPath); pErr == nil {
-				fmt.Fprintf(os.Stderr, "Worktree was created at %s, but hook failed\n", abs)
-			}
-			return err
-		}
-	}
 	return printCreatedWorktreePath(createdPath)
 }
 
@@ -149,20 +140,22 @@ func runAddInteractive() (string, error) {
 
 	wtPath := promptWorktreePath(branch)
 
-	// Create worktree from selected remote branch.
-	if err := ui.SpinWithOutputContext(fmt.Sprintf("Creating worktree for %s", ui.Accent(branch)), func(ctx context.Context, w io.Writer) error {
-		return git.RunToContext(ctx, w, "worktree", "add", "-b", branch, wtPath, selected.Value)
-	}); err != nil {
+	err = runAddLifecycle(wtPath, branch, func() error {
+		// Create worktree from selected remote branch.
+		if err := ui.SpinWithOutputContext(fmt.Sprintf("Creating worktree for %s", ui.Accent(branch)), func(ctx context.Context, w io.Writer) error {
+			return git.RunToContext(ctx, w, "worktree", "add", "-b", branch, wtPath, selected.Value)
+		}); err != nil {
+			return err
+		}
+
+		// Set upstream tracking.
+		return ui.SpinWithOutputContext(fmt.Sprintf("Setting upstream to %s", ui.Accent(selected.Value)), func(ctx context.Context, w io.Writer) error {
+			return git.RunToContext(ctx, w, "branch", "--set-upstream-to="+selected.Value, branch)
+		})
+	})
+	if err != nil {
 		return "", err
 	}
-
-	// Set upstream tracking.
-	if err := ui.SpinWithOutputContext(fmt.Sprintf("Setting upstream to %s", ui.Accent(selected.Value)), func(ctx context.Context, w io.Writer) error {
-		return git.RunToContext(ctx, w, "branch", "--set-upstream-to="+selected.Value, branch)
-	}); err != nil {
-		return "", err
-	}
-
 	return wtPath, nil
 }
 
@@ -176,9 +169,12 @@ func createNewBranch() (string, error) {
 
 	wtPath := promptWorktreePath(branchName)
 
-	if err := ui.SpinWithOutputContext(fmt.Sprintf("Creating worktree for %s", ui.Accent(branchName)), func(ctx context.Context, w io.Writer) error {
-		return git.RunToContext(ctx, w, "worktree", "add", "-b", branchName, wtPath)
-	}); err != nil {
+	err := runAddLifecycle(wtPath, branchName, func() error {
+		return ui.SpinWithOutputContext(fmt.Sprintf("Creating worktree for %s", ui.Accent(branchName)), func(ctx context.Context, w io.Writer) error {
+			return git.RunToContext(ctx, w, "worktree", "add", "-b", branchName, wtPath)
+		})
+	})
+	if err != nil {
 		return "", err
 	}
 	return wtPath, nil
@@ -221,35 +217,41 @@ func runAddDirect(cmd *cobra.Command, args []string, remote string) (string, err
 		createdPath = args[0]
 	}
 
-	// Create the worktree.
-	fullArgs := append([]string{"worktree", "add"}, gitArgs...)
-	if err := ui.SpinWithOutputContext("Creating worktree", func(ctx context.Context, w io.Writer) error {
-		return git.RunToContext(ctx, w, fullArgs...)
-	}); err != nil {
-		return "", err
-	}
-
-	// Set upstream tracking if -b/-B was used.
 	trackBranch := branch
 	if trackBranch == "" {
 		trackBranch = forceBranch
 	}
-	if trackBranch != "" && remote != "" {
-		if _, err := git.Query("rev-parse", "--verify", remote+"/"+trackBranch); err == nil {
-			if err := ui.SpinWithOutputContext(fmt.Sprintf("Setting upstream to %s", ui.Accent(remote+"/"+trackBranch)), func(ctx context.Context, w io.Writer) error {
-				return git.RunToContext(ctx, w, "branch", "--set-upstream-to="+remote+"/"+trackBranch, trackBranch)
-			}); err != nil {
-				return "", err
-			}
-		} else {
-			fmt.Fprintln(os.Stderr)
-			fmt.Fprintln(os.Stderr, renderCommandHintsSectionFor(os.Stderr, []commandHint{{
-				Action:  fmt.Sprintf("Push %s and set upstream", ui.Accent(trackBranch)),
-				Command: "git push -u " + remote + " " + trackBranch,
-			}}))
-		}
-	}
 
+	fullArgs := append([]string{"worktree", "add"}, gitArgs...)
+	err := runAddLifecycle(createdPath, trackBranch, func() error {
+		// Create the worktree.
+		if err := ui.SpinWithOutputContext("Creating worktree", func(ctx context.Context, w io.Writer) error {
+			return git.RunToContext(ctx, w, fullArgs...)
+		}); err != nil {
+			return err
+		}
+
+		// Set upstream tracking if -b/-B was used.
+		if trackBranch != "" && remote != "" {
+			if _, err := git.Query("rev-parse", "--verify", remote+"/"+trackBranch); err == nil {
+				if err := ui.SpinWithOutputContext(fmt.Sprintf("Setting upstream to %s", ui.Accent(remote+"/"+trackBranch)), func(ctx context.Context, w io.Writer) error {
+					return git.RunToContext(ctx, w, "branch", "--set-upstream-to="+remote+"/"+trackBranch, trackBranch)
+				}); err != nil {
+					return err
+				}
+			} else {
+				fmt.Fprintln(os.Stderr)
+				fmt.Fprintln(os.Stderr, renderCommandHintsSectionFor(os.Stderr, []commandHint{{
+					Action:  fmt.Sprintf("Push %s and set upstream", ui.Accent(trackBranch)),
+					Command: "git push -u " + remote + " " + trackBranch,
+				}}))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
 	return createdPath, nil
 }
 
@@ -258,19 +260,52 @@ func splitRemoteBranchRef(remoteRef string) (remote string, branch string) {
 	return remote, branch
 }
 
-func runAddHooks(wtPath string) error {
-	hooks, err := hook.LoadConfig("wt.addhook")
+func runAddLifecycle(wtPath, branch string, create func() error) error {
+	if wtPath == "" {
+		return create()
+	}
+
+	beforeHooks, err := hook.Load(hook.BeforeAdd)
 	if err != nil {
 		return err
 	}
-	if len(hooks) == 0 {
-		return nil
+	afterHooks, err := hook.Load(hook.AfterAdd)
+	if err != nil {
+		return err
 	}
+
 	absPath, err := filepath.Abs(wtPath)
 	if err != nil {
 		return err
 	}
-	return hook.Run(context.Background(), hooks, absPath, os.Stderr)
+	bareRoot, err := worktree.BareRoot()
+	if err != nil {
+		return err
+	}
+
+	invocation := hook.Invocation{
+		Event:        hook.BeforeAdd,
+		Dir:          bareRoot,
+		WorktreePath: absPath,
+		Branch:       branch,
+		BareRoot:     bareRoot,
+	}
+	if err := hook.Run(context.Background(), beforeHooks, invocation, os.Stderr); err != nil {
+		return err
+	}
+	if err := create(); err != nil {
+		return err
+	}
+
+	invocation.Event = hook.AfterAdd
+	invocation.Dir = absPath
+	if err := hook.Run(context.Background(), afterHooks, invocation, os.Stderr); err != nil {
+		if resolvedPath, pathErr := resolveCreatedPath(wtPath); pathErr == nil {
+			fmt.Fprintf(os.Stderr, "Worktree was created at %s, but wt.afteradd failed\n", resolvedPath)
+		}
+		return err
+	}
+	return nil
 }
 
 func resolveCreatedPath(path string) (string, error) {

--- a/internal/cmd/remove.go
+++ b/internal/cmd/remove.go
@@ -332,18 +332,32 @@ func confirmRemoval(items []removalItem, opts removeOptions, remote string, clea
 }
 
 type removalTarget struct {
-	path     string
-	branch   string
-	detached bool
+	path           string
+	branch         string
+	detached       bool
+	locked         bool
+	lockedReason   string
+	prunable       bool
+	prunableReason string
+}
+
+func newRemovalTargetFromEntry(entry worktree.Entry) removalTarget {
+	return removalTarget{
+		path:           entry.Path,
+		branch:         entry.Branch,
+		detached:       entry.Detached,
+		locked:         entry.Locked,
+		lockedReason:   entry.LockedReason,
+		prunable:       entry.Prunable,
+		prunableReason: entry.PrunableReason,
+	}
 }
 
 func newRemovalTarget(entries []worktree.Entry, path string) removalTarget {
-	t := removalTarget{path: path}
 	if entry := worktree.FindByPath(entries, path); entry != nil {
-		t.branch = entry.Branch
-		t.detached = entry.Detached
+		return newRemovalTargetFromEntry(*entry)
 	}
-	return t
+	return removalTarget{path: path}
 }
 
 func (t removalTarget) hasBranch() bool {
@@ -518,14 +532,46 @@ func pruneStaleWorktree(target removalTarget) error {
 	})
 }
 
+func preflightRemoveHook(target removalTarget) (bool, error) {
+	if currentRoot, err := currentWorktreeRoot(); err == nil && samePath(target.path, currentRoot) {
+		return false, fmt.Errorf("cannot remove current worktree %q", target.path)
+	}
+
+	if target.locked {
+		if target.lockedReason != "" {
+			return false, fmt.Errorf("cannot remove locked worktree %q: %s", target.path, target.lockedReason)
+		}
+		return false, fmt.Errorf("cannot remove locked worktree %q", target.path)
+	}
+
+	if target.prunable {
+		return false, nil
+	}
+
+	if _, err := os.Stat(target.path); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}
+
 func removeSingleWorktree(target removalTarget, deleteRemote bool, remote string) error {
 	name := filepath.Base(target.path)
 
-	if hooks, err := hook.LoadConfig("wt.deletehook"); err != nil {
+	runHooks, err := preflightRemoveHook(target)
+	if err != nil {
 		return err
-	} else if len(hooks) > 0 {
-		if err := hook.Run(context.Background(), hooks, target.path, os.Stderr); err != nil {
-			return fmt.Errorf("delete hook failed for worktree %q: %w", name, err)
+	}
+	if runHooks {
+		if hooks, err := hook.LoadConfig("wt.removehook"); err != nil {
+			return err
+		} else if len(hooks) > 0 {
+			if err := hook.Run(context.Background(), hooks, target.path, os.Stderr); err != nil {
+				return fmt.Errorf("remove hook failed for worktree %q: %w", name, err)
+			}
 		}
 	}
 

--- a/internal/cmd/remove.go
+++ b/internal/cmd/remove.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/ahmedelgabri/git-wt/internal/git"
+	"github.com/ahmedelgabri/git-wt/internal/hook"
 	"github.com/ahmedelgabri/git-wt/internal/picker"
 	"github.com/ahmedelgabri/git-wt/internal/ui"
 	"github.com/ahmedelgabri/git-wt/internal/worktree"
@@ -519,6 +520,14 @@ func pruneStaleWorktree(target removalTarget) error {
 
 func removeSingleWorktree(target removalTarget, deleteRemote bool, remote string) error {
 	name := filepath.Base(target.path)
+
+	if hooks, err := hook.LoadConfig("wt.deletehook"); err != nil {
+		return err
+	} else if len(hooks) > 0 {
+		if err := hook.Run(context.Background(), hooks, target.path, os.Stderr); err != nil {
+			return fmt.Errorf("delete hook failed for worktree %q: %w", name, err)
+		}
+	}
 
 	if err := ui.SpinWithOutputContext(fmt.Sprintf("Removing worktree %s", ui.Accent(name)), func(ctx context.Context, w io.Writer) error {
 		return git.RunToContext(ctx, w, "worktree", "remove", "-f", target.path)

--- a/internal/cmd/remove.go
+++ b/internal/cmd/remove.go
@@ -569,7 +569,15 @@ func removeSingleWorktree(target removalTarget, deleteRemote bool, remote string
 		if hooks, err := hook.LoadConfig("wt.removehook"); err != nil {
 			return err
 		} else if len(hooks) > 0 {
-			if err := hook.Run(context.Background(), hooks, target.path, os.Stderr); err != nil {
+			bareRoot, _ := worktree.BareRoot()
+			invocation := hook.Invocation{
+				Event:        hook.BeforeRemove,
+				Dir:          target.path,
+				WorktreePath: target.path,
+				Branch:       target.branch,
+				BareRoot:     bareRoot,
+			}
+			if err := hook.Run(context.Background(), hooks, invocation, os.Stderr); err != nil {
 				return fmt.Errorf("remove hook failed for worktree %q: %w", name, err)
 			}
 		}

--- a/internal/cmd/remove.go
+++ b/internal/cmd/remove.go
@@ -332,24 +332,22 @@ func confirmRemoval(items []removalItem, opts removeOptions, remote string, clea
 }
 
 type removalTarget struct {
-	path           string
-	branch         string
-	detached       bool
-	locked         bool
-	lockedReason   string
-	prunable       bool
-	prunableReason string
+	path         string
+	branch       string
+	detached     bool
+	locked       bool
+	lockedReason string
+	prunable     bool
 }
 
 func newRemovalTargetFromEntry(entry worktree.Entry) removalTarget {
 	return removalTarget{
-		path:           entry.Path,
-		branch:         entry.Branch,
-		detached:       entry.Detached,
-		locked:         entry.Locked,
-		lockedReason:   entry.LockedReason,
-		prunable:       entry.Prunable,
-		prunableReason: entry.PrunableReason,
+		path:         entry.Path,
+		branch:       entry.Branch,
+		detached:     entry.Detached,
+		locked:       entry.Locked,
+		lockedReason: entry.LockedReason,
+		prunable:     entry.Prunable,
 	}
 }
 
@@ -489,6 +487,7 @@ func removalReason(item removalItem) string {
 func executeRemovalItems(items []removalItem, deleteRemote bool, remote string) error {
 	successCount := 0
 	failedCount := 0
+	var singleErr error
 
 	for i, item := range items {
 		if len(items) > 1 {
@@ -505,6 +504,11 @@ func executeRemovalItems(items []removalItem, deleteRemote bool, remote string) 
 		}
 		if err != nil {
 			failedCount++
+			if len(items) == 1 {
+				singleErr = err
+			} else {
+				fmt.Fprintf(os.Stderr, "%s: %v\n", item.Target.path, err)
+			}
 		} else {
 			successCount++
 		}
@@ -519,6 +523,9 @@ func executeRemovalItems(items []removalItem, deleteRemote bool, remote string) 
 		fmt.Println(summary)
 	}
 
+	if singleErr != nil {
+		return singleErr
+	}
 	if failedCount > 0 {
 		return fmt.Errorf("%d removal(s) failed", failedCount)
 	}
@@ -565,21 +572,37 @@ func removeSingleWorktree(target removalTarget, deleteRemote bool, remote string
 	if err != nil {
 		return err
 	}
+
+	var beforeHooks, afterHooks []string
 	if runHooks {
-		if hooks, err := hook.LoadConfig("wt.removehook"); err != nil {
+		beforeHooks, err = hook.Load(hook.BeforeRemove)
+		if err != nil {
 			return err
-		} else if len(hooks) > 0 {
-			bareRoot, _ := worktree.BareRoot()
-			invocation := hook.Invocation{
-				Event:        hook.BeforeRemove,
-				Dir:          target.path,
-				WorktreePath: target.path,
-				Branch:       target.branch,
-				BareRoot:     bareRoot,
-			}
-			if err := hook.Run(context.Background(), hooks, invocation, os.Stderr); err != nil {
-				return fmt.Errorf("remove hook failed for worktree %q: %w", name, err)
-			}
+		}
+		afterHooks, err = hook.Load(hook.AfterRemove)
+		if err != nil {
+			return err
+		}
+		runHooks = len(beforeHooks) > 0 || len(afterHooks) > 0
+	}
+
+	var bareRoot string
+	if runHooks {
+		bareRoot, err = worktree.BareRoot()
+		if err != nil {
+			return err
+		}
+	}
+	invocation := hook.Invocation{
+		Event:        hook.BeforeRemove,
+		Dir:          target.path,
+		WorktreePath: target.path,
+		Branch:       target.branch,
+		BareRoot:     bareRoot,
+	}
+	if runHooks {
+		if err := hook.Run(context.Background(), beforeHooks, invocation, os.Stderr); err != nil {
+			return fmt.Errorf("before removing worktree %q: %w", name, err)
 		}
 	}
 
@@ -589,23 +612,28 @@ func removeSingleWorktree(target removalTarget, deleteRemote bool, remote string
 		return err
 	}
 
-	if !target.hasBranch() {
-		return nil
-	}
-
-	out, err := git.RunWithOutput("branch", "-D", target.branch)
-	if err != nil {
-		if out != "" {
-			return fmt.Errorf("%s", strings.TrimSpace(out))
+	if target.hasBranch() {
+		out, err := git.RunWithOutput("branch", "-D", target.branch)
+		if err != nil {
+			if out != "" {
+				return fmt.Errorf("%s", strings.TrimSpace(out))
+			}
+			return err
 		}
-		return err
-	}
-	ui.Successf("Deleted local branch %s", ui.Accent(target.branch))
+		ui.Successf("Deleted local branch %s", ui.Accent(target.branch))
 
-	if deleteRemote {
-		deleteRemoteBranch(target.branch, remote)
+		if deleteRemote {
+			deleteRemoteBranch(target.branch, remote)
+		}
 	}
 
+	if runHooks {
+		invocation.Event = hook.AfterRemove
+		invocation.Dir = bareRoot
+		if err := hook.Run(context.Background(), afterHooks, invocation, os.Stderr); err != nil {
+			return fmt.Errorf("worktree %q was removed, but %w", name, err)
+		}
+	}
 	return nil
 }
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -24,6 +24,9 @@ type ExecOptions struct {
 // debug returns whether mutation commands should be echoed instead of executed.
 func debug() bool { return os.Getenv("DEBUG") != "" }
 
+// Debug reports whether DEBUG mode is enabled, for callers outside this package.
+func Debug() bool { return debug() }
+
 func execGit(opts ExecOptions, args ...string) (string, error) {
 	if opts.Mutating && debug() {
 		msg := formatDebugCommand(opts.Dir, args)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -16,6 +16,7 @@ type ExecOptions struct {
 	StreamTo io.Writer
 	Capture  bool
 	Combined bool
+	Raw      bool
 	Env      []string
 	Context  context.Context
 	Stdin    io.Reader
@@ -63,6 +64,9 @@ func execGit(opts ExecOptions, args ...string) (string, error) {
 			out, err = cmd.CombinedOutput()
 		} else {
 			out, err = cmd.Output()
+		}
+		if opts.Raw {
+			return string(out), err
 		}
 		return strings.TrimSpace(string(out)), err
 	}
@@ -169,6 +173,16 @@ func Query(args ...string) (string, error) {
 // QueryContext executes a read-only git command with an optional context.
 func QueryContext(ctx context.Context, args ...string) (string, error) {
 	return execGit(ExecOptions{Capture: true, Context: ctx}, args...)
+}
+
+// QueryRaw executes a read-only git command without trimming its output.
+func QueryRaw(args ...string) (string, error) {
+	return QueryRawContext(context.Background(), args...)
+}
+
+// QueryRawContext executes a read-only git command without trimming its output.
+func QueryRawContext(ctx context.Context, args ...string) (string, error) {
+	return execGit(ExecOptions{Capture: true, Raw: true, Context: ctx}, args...)
 }
 
 // QueryRun executes a read-only git command, streaming stdout/stderr directly.

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -18,6 +18,16 @@ func TestQueryVersion(t *testing.T) {
 	}
 }
 
+func TestQueryRawPreservesWhitespace(t *testing.T) {
+	out, err := QueryRaw("-c", "raw.value=  value  ", "config", "--null", "--get-regexp", "^raw\\.")
+	if err != nil {
+		t.Fatalf("QueryRaw(config) error: %v", err)
+	}
+	if out != "raw.value\n  value  \x00" {
+		t.Errorf("QueryRaw(config) = %q, want untrimmed output", out)
+	}
+}
+
 func TestQueryRun(t *testing.T) {
 	if err := QueryRun("--version"); err != nil {
 		t.Fatalf("QueryRun(--version) error: %v", err)

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -1,0 +1,38 @@
+package hook
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+
+	"github.com/ahmedelgabri/git-wt/internal/git"
+)
+
+func LoadConfig(key string) ([]string, error) {
+	out, err := git.Query("config", "--get-all", key)
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if out == "" {
+		return nil, nil
+	}
+	return strings.Split(out, "\n"), nil
+}
+
+func Run(ctx context.Context, hooks []string, dir string, w io.Writer) error {
+	for _, h := range hooks {
+		cmd := exec.CommandContext(ctx, "sh", "-c", h)
+		cmd.Dir = dir
+		cmd.Stdout = w
+		cmd.Stderr = w
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("hook %q failed: %w", h, err)
+		}
+	}
+	return nil
+}

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -11,17 +11,18 @@ import (
 )
 
 func LoadConfig(key string) ([]string, error) {
-	out, err := git.Query("config", "--get-all", key)
+	out, err := git.QueryRaw("config", "--null", "--get-all", key)
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
 			return nil, nil
 		}
 		return nil, err
 	}
+	out = strings.TrimSuffix(out, "\x00")
 	if out == "" {
 		return nil, nil
 	}
-	return strings.Split(out, "\n"), nil
+	return strings.Split(out, "\x00"), nil
 }
 
 func Run(ctx context.Context, hooks []string, dir string, w io.Writer) error {

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -26,6 +26,10 @@ func LoadConfig(key string) ([]string, error) {
 
 func Run(ctx context.Context, hooks []string, dir string, w io.Writer) error {
 	for _, h := range hooks {
+		if git.Debug() {
+			fmt.Fprintf(w, "[in %s] sh -c %s\n", dir, h)
+			continue
+		}
 		cmd := exec.CommandContext(ctx, "sh", "-c", h)
 		cmd.Dir = dir
 		cmd.Stdout = w

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -4,11 +4,33 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/ahmedelgabri/git-wt/internal/git"
 )
+
+type Event string
+
+const (
+	BeforeAdd    Event = "beforeadd"
+	AfterAdd     Event = "afteradd"
+	BeforeRemove Event = "beforeremove"
+	AfterRemove  Event = "afterremove"
+)
+
+type Invocation struct {
+	Event        Event
+	Dir          string
+	WorktreePath string
+	Branch       string
+	BareRoot     string
+}
+
+func Load(event Event) ([]string, error) {
+	return LoadConfig("wt." + string(event))
+}
 
 func LoadConfig(key string) ([]string, error) {
 	out, err := git.QueryRaw("config", "--null", "--get-all", key)
@@ -25,19 +47,30 @@ func LoadConfig(key string) ([]string, error) {
 	return strings.Split(out, "\x00"), nil
 }
 
-func Run(ctx context.Context, hooks []string, dir string, w io.Writer) error {
+func Run(ctx context.Context, hooks []string, invocation Invocation, w io.Writer) error {
 	for _, h := range hooks {
 		if git.Debug() {
-			fmt.Fprintf(w, "[in %s] sh -c %s\n", dir, h)
+			fmt.Fprintf(w, "[%s in %s] sh -c %s\n", configKey(invocation.Event), invocation.Dir, h)
 			continue
 		}
 		cmd := exec.CommandContext(ctx, "sh", "-c", h)
-		cmd.Dir = dir
+		cmd.Dir = invocation.Dir
+		cmd.Env = append(
+			os.Environ(),
+			"GIT_WT_EVENT="+string(invocation.Event),
+			"GIT_WT_PATH="+invocation.WorktreePath,
+			"GIT_WT_BRANCH="+invocation.Branch,
+			"GIT_WT_BARE_ROOT="+invocation.BareRoot,
+		)
 		cmd.Stdout = w
 		cmd.Stderr = w
 		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("hook %q failed: %w", h, err)
+			return fmt.Errorf("%s hook %q failed: %w", configKey(invocation.Event), h, err)
 		}
 	}
 	return nil
+}
+
+func configKey(event Event) string {
+	return "wt." + string(event)
 }

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -1,7 +1,12 @@
 package hook
 
 import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -31,5 +36,65 @@ func TestLoadConfigReturnsNilForMissingKey(t *testing.T) {
 	}
 	if hooks != nil {
 		t.Fatalf("LoadConfig() = %#v, want nil", hooks)
+	}
+}
+
+func TestRunSetsLifecycleEnvironmentAndDirectory(t *testing.T) {
+	dir := t.TempDir()
+	output := filepath.Join(dir, "context")
+	invocation := Invocation{
+		Event:        BeforeAdd,
+		Dir:          dir,
+		WorktreePath: filepath.Join(dir, "worktree"),
+		Branch:       "feature",
+		BareRoot:     dir,
+	}
+	hooks := []string{"printf '%s\\n%s\\n%s\\n%s\\n%s\\n' \"$PWD\" \"$GIT_WT_EVENT\" \"$GIT_WT_PATH\" \"$GIT_WT_BRANCH\" \"$GIT_WT_BARE_ROOT\" > context"}
+
+	if err := Run(context.Background(), hooks, invocation, os.Stderr); err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	got, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	resolvedDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks() error: %v", err)
+	}
+	want := strings.Join([]string{resolvedDir, "beforeadd", invocation.WorktreePath, "feature", dir, ""}, "\n")
+	if string(got) != want {
+		t.Fatalf("hook context = %q, want %q", got, want)
+	}
+}
+
+func TestRunStopsAfterFirstFailure(t *testing.T) {
+	dir := t.TempDir()
+	invocation := Invocation{Event: AfterAdd, Dir: dir}
+	hooks := []string{"exit 7", "touch second-ran"}
+
+	err := Run(context.Background(), hooks, invocation, os.Stderr)
+	if err == nil || !strings.Contains(err.Error(), "wt.afteradd") {
+		t.Fatalf("Run() error = %v, want wt.afteradd failure", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "second-ran")); !os.IsNotExist(err) {
+		t.Fatalf("second hook ran after failure: %v", err)
+	}
+}
+
+func TestRunDebugEchoesWithoutExecuting(t *testing.T) {
+	t.Setenv("DEBUG", "1")
+	dir := t.TempDir()
+	invocation := Invocation{Event: BeforeRemove, Dir: dir}
+	var output bytes.Buffer
+
+	if err := Run(context.Background(), []string{"touch should-not-run"}, invocation, &output); err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if !strings.Contains(output.String(), "wt.beforeremove") {
+		t.Fatalf("debug output = %q, want event name", output.String())
+	}
+	if _, err := os.Stat(filepath.Join(dir, "should-not-run")); !os.IsNotExist(err) {
+		t.Fatalf("debug hook executed: %v", err)
 	}
 }

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -1,0 +1,35 @@
+package hook
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestLoadConfigPreservesMultilineValues(t *testing.T) {
+	t.Setenv("GIT_CONFIG_COUNT", "2")
+	t.Setenv("GIT_CONFIG_KEY_0", "wt.testhook")
+	t.Setenv("GIT_CONFIG_VALUE_0", "printf 'first\\nsecond\\n'")
+	t.Setenv("GIT_CONFIG_KEY_1", "wt.testhook")
+	t.Setenv("GIT_CONFIG_VALUE_1", "touch done")
+
+	hooks, err := LoadConfig("wt.testhook")
+	if err != nil {
+		t.Fatalf("LoadConfig() error: %v", err)
+	}
+	want := []string{"printf 'first\\nsecond\\n'", "touch done"}
+	if !slices.Equal(hooks, want) {
+		t.Fatalf("LoadConfig() = %#v, want %#v", hooks, want)
+	}
+}
+
+func TestLoadConfigReturnsNilForMissingKey(t *testing.T) {
+	t.Setenv("GIT_CONFIG_COUNT", "0")
+
+	hooks, err := LoadConfig("wt.missing")
+	if err != nil {
+		t.Fatalf("LoadConfig() error: %v", err)
+	}
+	if hooks != nil {
+		t.Fatalf("LoadConfig() = %#v, want nil", hooks)
+	}
+}

--- a/tests/hooks.bats
+++ b/tests/hooks.bats
@@ -10,34 +10,60 @@ teardown() {
 	teardown_test_env
 }
 
-# --- Post-creation hooks (wt.addhook) ---
+# --- Add lifecycle hooks ---
 
-@test "hooks: wt.addhook runs after creating worktree" {
+@test "hooks: wt.beforeadd runs from bare root before creating worktree" {
 	init_bare_repo_with_remote myrepo
 	cd myrepo
-	command git config --add wt.addhook 'touch .hook-ran'
+	command git config --add wt.beforeadd '[ ! -e "$GIT_WT_PATH" ] && printf "%s\\n%s\\n%s\\n%s\\n" "$PWD" "$GIT_WT_EVENT" "$GIT_WT_BRANCH" "$GIT_WT_PATH" > .beforeadd-context'
+
+	run "$GIT_WT" add -b before-add before-add
+	[ "$status" -eq 0 ]
+	local context
+	context=$(cat "$TEST_DIR/myrepo/.beforeadd-context")
+	[[ "$context" == "$TEST_DIR/myrepo"$'\n'"beforeadd"$'\n'"before-add"$'\n'"$TEST_DIR/myrepo/before-add" ]]
+}
+
+@test "hooks: wt.beforeadd failure prevents worktree creation and later hooks" {
+	init_bare_repo_with_remote myrepo
+	cd myrepo
+	command git config --add wt.beforeadd 'exit 1'
+	command git config --add wt.beforeadd 'touch .second-ran'
+	command git config --add wt.afteradd 'touch .after-ran'
+
+	run "$GIT_WT" add -b before-fail before-fail
+	[ "$status" -ne 0 ]
+	[ ! -e "$TEST_DIR/myrepo/before-fail" ]
+	[ ! -e "$TEST_DIR/myrepo/.second-ran" ]
+	[ ! -e "$TEST_DIR/myrepo/before-fail/.after-ran" ]
+}
+
+@test "hooks: wt.afteradd runs after creating worktree" {
+	init_bare_repo_with_remote myrepo
+	cd myrepo
+	command git config --add wt.afteradd 'touch .hook-ran'
 
 	run "$GIT_WT" add -b hook-test hook-test
 	[ "$status" -eq 0 ]
 	[ -f "$TEST_DIR/myrepo/hook-test/.hook-ran" ]
 }
 
-@test "hooks: wt.addhook runs in the new worktree directory" {
+@test "hooks: wt.afteradd runs in the new worktree with lifecycle environment" {
 	init_bare_repo_with_remote myrepo
 	cd myrepo
-	command git config --add wt.addhook 'pwd > .hook-pwd'
+	command git config --add wt.afteradd 'printf "%s\\n%s\\n%s\\n%s\\n%s\\n" "$PWD" "$GIT_WT_EVENT" "$GIT_WT_PATH" "$GIT_WT_BRANCH" "$GIT_WT_BARE_ROOT" > .hook-context'
 
 	"$GIT_WT" add -b hook-dir hook-dir
-	local hook_pwd
-	hook_pwd=$(cat "$TEST_DIR/myrepo/hook-dir/.hook-pwd")
-	[ "$hook_pwd" = "$TEST_DIR/myrepo/hook-dir" ]
+	local context
+	context=$(cat "$TEST_DIR/myrepo/hook-dir/.hook-context")
+	[[ "$context" == "$TEST_DIR/myrepo/hook-dir"$'\n'"afteradd"$'\n'"$TEST_DIR/myrepo/hook-dir"$'\n'"hook-dir"$'\n'"$TEST_DIR/myrepo" ]]
 }
 
-@test "hooks: multiple wt.addhook values run sequentially" {
+@test "hooks: multiple wt.afteradd values run sequentially" {
 	init_bare_repo_with_remote myrepo
 	cd myrepo
-	command git config --add wt.addhook 'echo first >> .hook-order'
-	command git config --add wt.addhook 'echo second >> .hook-order'
+	command git config --add wt.afteradd 'echo first >> .hook-order'
+	command git config --add wt.afteradd 'echo second >> .hook-order'
 
 	"$GIT_WT" add -b multi-hook multi-hook
 
@@ -49,11 +75,21 @@ teardown() {
 	[ "$(head -1 "$TEST_DIR/myrepo/multi-hook/.hook-order")" = "first" ]
 }
 
-@test "hooks: wt.addhook failure stops execution and returns error" {
+@test "hooks: multiline wt.afteradd remains a single command" {
 	init_bare_repo_with_remote myrepo
 	cd myrepo
-	command git config --add wt.addhook 'exit 1'
-	command git config --add wt.addhook 'touch .second-ran'
+	command git config --add wt.afteradd $'if true; then\n\ttouch .multiline-ran\nfi'
+
+	run "$GIT_WT" add -b multiline-hook multiline-hook
+	[ "$status" -eq 0 ]
+	[ -f "$TEST_DIR/myrepo/multiline-hook/.multiline-ran" ]
+}
+
+@test "hooks: wt.afteradd failure stops execution and returns error" {
+	init_bare_repo_with_remote myrepo
+	cd myrepo
+	command git config --add wt.afteradd 'exit 1'
+	command git config --add wt.afteradd 'touch .second-ran'
 
 	run "$GIT_WT" add -b fail-hook fail-hook
 	[ "$status" -ne 0 ]
@@ -61,10 +97,10 @@ teardown() {
 	[ ! -f "$TEST_DIR/myrepo/fail-hook/.second-ran" ]
 }
 
-@test "hooks: wt.addhook failure does not print success path to stdout" {
+@test "hooks: wt.afteradd failure does not print success path to stdout" {
 	init_bare_repo_with_remote myrepo
 	cd myrepo
-	command git config --add wt.addhook 'exit 1'
+	command git config --add wt.afteradd 'exit 1'
 
 	local stdout_file stderr_file
 	stdout_file="$TEST_DIR/stdout.txt"
@@ -81,7 +117,7 @@ teardown() {
 	[[ "$(cat "$stderr_file")" == *"$TEST_DIR/myrepo/fail-stdout"* ]]
 }
 
-@test "hooks: wt.addhook does not run when no hooks configured" {
+@test "hooks: wt.afteradd does not run when no hooks configured" {
 	init_bare_repo_with_remote myrepo
 	cd myrepo
 
@@ -90,10 +126,10 @@ teardown() {
 	assert_worktree_exists "$TEST_DIR/myrepo/no-hook"
 }
 
-@test "hooks: wt.addhook output goes to stderr" {
+@test "hooks: wt.afteradd output goes to stderr" {
 	init_bare_repo_with_remote myrepo
 	cd myrepo
-	command git config --add wt.addhook 'echo hook-output'
+	command git config --add wt.afteradd 'echo hook-output'
 
 	local stdout_file stderr_file
 	stdout_file="$TEST_DIR/stdout.txt"
@@ -107,10 +143,10 @@ teardown() {
 	[[ "$(cat "$stderr_file")" == *"hook-output"* ]]
 }
 
-@test "hooks: wt.addhook is echoed, not executed, under DEBUG=1" {
+@test "hooks: wt.afteradd is echoed, not executed, under DEBUG=1" {
 	init_bare_repo_with_remote myrepo
 	cd myrepo
-	command git config --add wt.addhook 'touch .should-not-run'
+	command git config --add wt.afteradd 'touch .should-not-run'
 
 	run env DEBUG=1 "$GIT_WT" add -b dbg-hook dbg-hook
 	[ "$status" -eq 0 ]
@@ -120,10 +156,10 @@ teardown() {
 	[ ! -f "$TEST_DIR/myrepo/dbg-hook/.should-not-run" ]
 }
 
-@test "hooks: wt.addhook runs in interactive mode" {
+@test "hooks: wt.afteradd runs in interactive mode" {
 	init_bare_repo_with_remote myrepo
 	cd myrepo
-	command git config --add wt.addhook 'touch .hook-ran'
+	command git config --add wt.afteradd 'touch .hook-ran'
 	command git checkout -b interactive-hook --quiet
 	create_commit "interactive-hook.txt"
 	command git push --quiet -u origin interactive-hook
@@ -135,7 +171,7 @@ teardown() {
 	[ -f "$TEST_DIR/myrepo/interactive-hook/.hook-ran" ]
 }
 
-# --- Delete hooks (wt.removehook) ---
+# --- Remove lifecycle hooks ---
 
 @test "hooks: wt.removehook runs before removing worktree" {
 	init_bare_repo myrepo

--- a/tests/hooks.bats
+++ b/tests/hooks.bats
@@ -173,11 +173,11 @@ teardown() {
 
 # --- Remove lifecycle hooks ---
 
-@test "hooks: wt.removehook runs before removing worktree" {
+@test "hooks: wt.beforeremove runs before removing worktree" {
 	init_bare_repo myrepo
 	cd myrepo
 	create_worktree del-hook del-hook
-	command git config --add wt.removehook 'touch "$TEST_DIR/delete-hook-ran"'
+	command git config --add wt.beforeremove 'touch "$TEST_DIR/delete-hook-ran"'
 
 	run bash -c 'printf "y\n" | "$1" remove "$2"' _ "$GIT_WT" "$TEST_DIR/myrepo/del-hook"
 	[ "$status" -eq 0 ]
@@ -185,36 +185,37 @@ teardown() {
 	assert_worktree_not_exists "$TEST_DIR/myrepo/del-hook"
 }
 
-@test "hooks: wt.removehook runs in the worktree directory" {
+@test "hooks: wt.beforeremove runs in the worktree with lifecycle environment" {
 	init_bare_repo myrepo
 	cd myrepo
 	create_worktree del-dir del-dir
-	command git config --add wt.removehook 'pwd > "$TEST_DIR/delete-hook-pwd"'
+	command git config --add wt.beforeremove 'printf "%s\\n%s\\n%s\\n%s\\n%s\\n" "$PWD" "$GIT_WT_EVENT" "$GIT_WT_PATH" "$GIT_WT_BRANCH" "$GIT_WT_BARE_ROOT" > "$TEST_DIR/beforeremove-context"'
 
 	run bash -c 'printf "y\n" | "$1" remove "$2"' _ "$GIT_WT" "$TEST_DIR/myrepo/del-dir"
 	[ "$status" -eq 0 ]
-	local hook_pwd
-	hook_pwd=$(cat "$TEST_DIR/delete-hook-pwd")
-	[ "$hook_pwd" = "$TEST_DIR/myrepo/del-dir" ]
+	local context
+	context=$(cat "$TEST_DIR/beforeremove-context")
+	[[ "$context" == "$TEST_DIR/myrepo/del-dir"$'\n'"beforeremove"$'\n'"$TEST_DIR/myrepo/del-dir"$'\n'"del-dir"$'\n'"$TEST_DIR/myrepo" ]]
 }
 
-@test "hooks: wt.removehook failure prevents worktree removal" {
+@test "hooks: wt.beforeremove failure prevents worktree removal" {
 	init_bare_repo myrepo
 	cd myrepo
 	create_worktree del-fail del-fail
-	command git config --add wt.removehook 'exit 1'
+	command git config --add wt.beforeremove 'exit 1'
 
 	run bash -c 'printf "y\n" | "$1" remove "$2"' _ "$GIT_WT" "$TEST_DIR/myrepo/del-fail"
 	[ "$status" -ne 0 ]
+	[[ "$output" == *"wt.beforeremove"* ]]
 	assert_worktree_exists "$TEST_DIR/myrepo/del-fail"
 }
 
-@test "hooks: multiple wt.removehook values run sequentially" {
+@test "hooks: multiple wt.beforeremove values run sequentially" {
 	init_bare_repo myrepo
 	cd myrepo
 	create_worktree del-multi del-multi
-	command git config --add wt.removehook 'echo first >> "$TEST_DIR/del-hook-order"'
-	command git config --add wt.removehook 'echo second >> "$TEST_DIR/del-hook-order"'
+	command git config --add wt.beforeremove 'echo first >> "$TEST_DIR/del-hook-order"'
+	command git config --add wt.beforeremove 'echo second >> "$TEST_DIR/del-hook-order"'
 
 	run bash -c 'printf "y\n" | "$1" remove "$2"' _ "$GIT_WT" "$TEST_DIR/myrepo/del-multi"
 	[ "$status" -eq 0 ]
@@ -222,31 +223,98 @@ teardown() {
 	[ "$(tail -1 "$TEST_DIR/del-hook-order")" = "second" ]
 }
 
-@test "hooks: wt.removehook does not run for stale prune" {
+@test "hooks: wt.afterremove runs from bare root after worktree and branch cleanup" {
+	init_bare_repo myrepo
+	cd myrepo
+	create_worktree after-remove after-remove
+	command git config --add wt.afterremove '[ ! -e "$GIT_WT_PATH" ] && ! git show-ref --verify --quiet "refs/heads/$GIT_WT_BRANCH" && printf "%s\\n%s\\n%s\\n%s\\n%s\\n" "$PWD" "$GIT_WT_EVENT" "$GIT_WT_PATH" "$GIT_WT_BRANCH" "$GIT_WT_BARE_ROOT" > "$TEST_DIR/afterremove-context"'
+
+	run bash -c 'printf "y\n" | "$1" remove "$2"' _ "$GIT_WT" "$TEST_DIR/myrepo/after-remove"
+	[ "$status" -eq 0 ]
+	local context
+	context=$(cat "$TEST_DIR/afterremove-context")
+	[[ "$context" == "$TEST_DIR/myrepo"$'\n'"afterremove"$'\n'"$TEST_DIR/myrepo/after-remove"$'\n'"after-remove"$'\n'"$TEST_DIR/myrepo" ]]
+}
+
+@test "hooks: wt.afterremove failure reports that removal remains complete" {
+	init_bare_repo myrepo
+	cd myrepo
+	create_worktree after-fail after-fail
+	command git config --add wt.afterremove 'exit 1'
+
+	run bash -c 'printf "y\n" | "$1" remove "$2"' _ "$GIT_WT" "$TEST_DIR/myrepo/after-fail"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"was removed"* ]]
+	[[ "$output" == *"wt.afterremove"* ]]
+	assert_worktree_not_exists "$TEST_DIR/myrepo/after-fail"
+	run command git show-ref --verify --quiet refs/heads/after-fail
+	[ "$status" -ne 0 ]
+}
+
+@test "hooks: remove continues after one target hook fails and reports the target" {
+	init_bare_repo myrepo
+	cd myrepo
+	create_worktree fail-one fail-one
+	create_worktree pass-two pass-two
+	command git config --add wt.beforeremove '[ "$(basename "$GIT_WT_PATH")" != fail-one ]'
+
+	local stdout_file stderr_file
+	stdout_file="$TEST_DIR/remove-stdout.txt"
+	stderr_file="$TEST_DIR/remove-stderr.txt"
+	run bash -c 'printf "y\n" | "$1" remove "$2" "$3" >"$4" 2>"$5"' _ "$GIT_WT" "$TEST_DIR/myrepo/fail-one" "$TEST_DIR/myrepo/pass-two" "$stdout_file" "$stderr_file"
+
+	[ "$status" -ne 0 ]
+	assert_worktree_exists "$TEST_DIR/myrepo/fail-one"
+	assert_worktree_not_exists "$TEST_DIR/myrepo/pass-two"
+	[[ "$(cat "$stderr_file")" == *"$TEST_DIR/myrepo/fail-one"* ]]
+	[[ "$(cat "$stderr_file")" == *"wt.beforeremove"* ]]
+}
+
+@test "hooks: remove hooks do not run for stale prune" {
 	init_bare_repo myrepo
 	cd myrepo
 	create_worktree stale-prune stale-prune
-	command git config --add wt.removehook 'touch "$TEST_DIR/prune-hook-ran"'
+	command git config --add wt.beforeremove 'touch "$TEST_DIR/before-prune-hook-ran"'
+	command git config --add wt.afterremove 'touch "$TEST_DIR/after-prune-hook-ran"'
 
 	# Manually remove the worktree directory to make it stale
 	rm -rf "$TEST_DIR/myrepo/stale-prune"
 
 	run "$GIT_WT" remove --stale
-	# Hook should NOT have run (prune path doesn't call removeSingleWorktree)
-	[ ! -f "$TEST_DIR/prune-hook-ran" ]
+	[ ! -f "$TEST_DIR/before-prune-hook-ran" ]
+	[ ! -f "$TEST_DIR/after-prune-hook-ran" ]
 }
 
-@test "hooks: wt.removehook does not run when removing current worktree is rejected" {
+@test "hooks: wt.beforeremove does not run when removing current worktree is rejected" {
 	init_bare_repo myrepo
 	cd myrepo
 	create_worktree del-current del-current
-	command git config --add wt.removehook 'touch "$TEST_DIR/remove-hook-should-not-run"'
+	command git config --add wt.beforeremove 'touch "$TEST_DIR/before-remove-should-not-run"'
+	command git config --add wt.afterremove 'touch "$TEST_DIR/after-remove-should-not-run"'
 
 	# Removing the worktree we are standing in is rejected before hooks run.
 	cd "$TEST_DIR/myrepo/del-current"
 	run bash -c 'printf "y\n" | "$1" remove "$2"' _ "$GIT_WT" "$TEST_DIR/myrepo/del-current"
 
 	[ "$status" -ne 0 ]
-	[ ! -f "$TEST_DIR/remove-hook-should-not-run" ]
+	[ ! -f "$TEST_DIR/before-remove-should-not-run" ]
+	[ ! -f "$TEST_DIR/after-remove-should-not-run" ]
 	assert_worktree_exists "$TEST_DIR/myrepo/del-current"
+}
+
+@test "hooks: remove hooks do not run for locked worktree" {
+	init_bare_repo myrepo
+	cd myrepo
+	create_worktree del-locked del-locked
+	command git worktree lock --reason testing "$TEST_DIR/myrepo/del-locked"
+	command git config --add wt.beforeremove 'touch "$TEST_DIR/before-locked-should-not-run"'
+	command git config --add wt.afterremove 'touch "$TEST_DIR/after-locked-should-not-run"'
+
+	run bash -c 'printf "y\n" | "$1" remove "$2"' _ "$GIT_WT" "$TEST_DIR/myrepo/del-locked"
+
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"testing"* ]]
+	[ ! -f "$TEST_DIR/before-locked-should-not-run" ]
+	[ ! -f "$TEST_DIR/after-locked-should-not-run" ]
+	assert_worktree_exists "$TEST_DIR/myrepo/del-locked"
 }

--- a/tests/hooks.bats
+++ b/tests/hooks.bats
@@ -1,0 +1,168 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+	setup_test_env
+}
+
+teardown() {
+	teardown_test_env
+}
+
+# --- Post-creation hooks (wt.hook) ---
+
+@test "hooks: wt.hook runs after creating worktree" {
+	init_bare_repo_with_remote myrepo
+	cd myrepo
+	command git config --add wt.hook 'touch .hook-ran'
+
+	run "$GIT_WT" add -b hook-test hook-test
+	[ "$status" -eq 0 ]
+	[ -f "$TEST_DIR/myrepo/hook-test/.hook-ran" ]
+}
+
+@test "hooks: wt.hook runs in the new worktree directory" {
+	init_bare_repo_with_remote myrepo
+	cd myrepo
+	command git config --add wt.hook 'pwd > .hook-pwd'
+
+	"$GIT_WT" add -b hook-dir hook-dir
+	local hook_pwd
+	hook_pwd=$(cat "$TEST_DIR/myrepo/hook-dir/.hook-pwd")
+	[ "$hook_pwd" = "$TEST_DIR/myrepo/hook-dir" ]
+}
+
+@test "hooks: multiple wt.hook values run sequentially" {
+	init_bare_repo_with_remote myrepo
+	cd myrepo
+	command git config --add wt.hook 'echo first >> .hook-order'
+	command git config --add wt.hook 'echo second >> .hook-order'
+
+	"$GIT_WT" add -b multi-hook multi-hook
+
+	local contents
+	contents=$(cat "$TEST_DIR/myrepo/multi-hook/.hook-order")
+	[[ "$contents" == *"first"* ]]
+	[[ "$contents" == *"second"* ]]
+	# Verify order
+	[ "$(head -1 "$TEST_DIR/myrepo/multi-hook/.hook-order")" = "first" ]
+}
+
+@test "hooks: wt.hook failure stops execution and returns error" {
+	init_bare_repo_with_remote myrepo
+	cd myrepo
+	command git config --add wt.hook 'exit 1'
+	command git config --add wt.hook 'touch .second-ran'
+
+	run "$GIT_WT" add -b fail-hook fail-hook
+	[ "$status" -ne 0 ]
+	# Second hook should not have run
+	[ ! -f "$TEST_DIR/myrepo/fail-hook/.second-ran" ]
+}
+
+@test "hooks: wt.hook does not run when no hooks configured" {
+	init_bare_repo_with_remote myrepo
+	cd myrepo
+
+	run "$GIT_WT" add -b no-hook no-hook
+	[ "$status" -eq 0 ]
+	assert_worktree_exists "$TEST_DIR/myrepo/no-hook"
+}
+
+@test "hooks: wt.hook output goes to stderr" {
+	init_bare_repo_with_remote myrepo
+	cd myrepo
+	command git config --add wt.hook 'echo hook-output'
+
+	local stdout_file stderr_file
+	stdout_file="$TEST_DIR/stdout.txt"
+	stderr_file="$TEST_DIR/stderr.txt"
+
+	"$GIT_WT" add -b stderr-hook stderr-hook >"$stdout_file" 2>"$stderr_file"
+
+	# stdout should only have the path
+	[[ "$(cat "$stdout_file")" == *"stderr-hook"* ]]
+	# stderr should contain hook output
+	[[ "$(cat "$stderr_file")" == *"hook-output"* ]]
+}
+
+@test "hooks: wt.hook runs in interactive mode" {
+	init_bare_repo_with_remote myrepo
+	cd myrepo
+	command git config --add wt.hook 'touch .hook-ran'
+	command git checkout -b interactive-hook --quiet
+	create_commit "interactive-hook.txt"
+	command git push --quiet -u origin interactive-hook
+	command git checkout main --quiet 2>/dev/null || command git checkout master --quiet
+	command git branch -D interactive-hook --quiet
+
+	run env GIT_WT_SELECT="origin/interactive-hook" "$GIT_WT" add
+	[ "$status" -eq 0 ]
+	[ -f "$TEST_DIR/myrepo/interactive-hook/.hook-ran" ]
+}
+
+# --- Delete hooks (wt.deletehook) ---
+
+@test "hooks: wt.deletehook runs before removing worktree" {
+	init_bare_repo myrepo
+	cd myrepo
+	create_worktree del-hook del-hook
+	command git config --add wt.deletehook 'touch "$TEST_DIR/delete-hook-ran"'
+
+	run bash -c 'printf "y\n" | "$1" remove "$2"' _ "$GIT_WT" "$TEST_DIR/myrepo/del-hook"
+	[ "$status" -eq 0 ]
+	[ -f "$TEST_DIR/delete-hook-ran" ]
+	assert_worktree_not_exists "$TEST_DIR/myrepo/del-hook"
+}
+
+@test "hooks: wt.deletehook runs in the worktree directory" {
+	init_bare_repo myrepo
+	cd myrepo
+	create_worktree del-dir del-dir
+	command git config --add wt.deletehook 'pwd > "$TEST_DIR/delete-hook-pwd"'
+
+	run bash -c 'printf "y\n" | "$1" remove "$2"' _ "$GIT_WT" "$TEST_DIR/myrepo/del-dir"
+	[ "$status" -eq 0 ]
+	local hook_pwd
+	hook_pwd=$(cat "$TEST_DIR/delete-hook-pwd")
+	[ "$hook_pwd" = "$TEST_DIR/myrepo/del-dir" ]
+}
+
+@test "hooks: wt.deletehook failure prevents worktree removal" {
+	init_bare_repo myrepo
+	cd myrepo
+	create_worktree del-fail del-fail
+	command git config --add wt.deletehook 'exit 1'
+
+	run bash -c 'printf "y\n" | "$1" remove "$2"' _ "$GIT_WT" "$TEST_DIR/myrepo/del-fail"
+	[ "$status" -ne 0 ]
+	assert_worktree_exists "$TEST_DIR/myrepo/del-fail"
+}
+
+@test "hooks: multiple wt.deletehook values run sequentially" {
+	init_bare_repo myrepo
+	cd myrepo
+	create_worktree del-multi del-multi
+	command git config --add wt.deletehook 'echo first >> "$TEST_DIR/del-hook-order"'
+	command git config --add wt.deletehook 'echo second >> "$TEST_DIR/del-hook-order"'
+
+	run bash -c 'printf "y\n" | "$1" remove "$2"' _ "$GIT_WT" "$TEST_DIR/myrepo/del-multi"
+	[ "$status" -eq 0 ]
+	[ "$(head -1 "$TEST_DIR/del-hook-order")" = "first" ]
+	[ "$(tail -1 "$TEST_DIR/del-hook-order")" = "second" ]
+}
+
+@test "hooks: wt.deletehook does not run for stale prune" {
+	init_bare_repo myrepo
+	cd myrepo
+	create_worktree stale-prune stale-prune
+	command git config --add wt.deletehook 'touch "$TEST_DIR/prune-hook-ran"'
+
+	# Manually remove the worktree directory to make it stale
+	rm -rf "$TEST_DIR/myrepo/stale-prune"
+
+	run "$GIT_WT" remove --stale
+	# Hook should NOT have run (prune path doesn't call removeSingleWorktree)
+	[ ! -f "$TEST_DIR/prune-hook-ran" ]
+}

--- a/tests/hooks.bats
+++ b/tests/hooks.bats
@@ -10,22 +10,22 @@ teardown() {
 	teardown_test_env
 }
 
-# --- Post-creation hooks (wt.hook) ---
+# --- Post-creation hooks (wt.addhook) ---
 
-@test "hooks: wt.hook runs after creating worktree" {
+@test "hooks: wt.addhook runs after creating worktree" {
 	init_bare_repo_with_remote myrepo
 	cd myrepo
-	command git config --add wt.hook 'touch .hook-ran'
+	command git config --add wt.addhook 'touch .hook-ran'
 
 	run "$GIT_WT" add -b hook-test hook-test
 	[ "$status" -eq 0 ]
 	[ -f "$TEST_DIR/myrepo/hook-test/.hook-ran" ]
 }
 
-@test "hooks: wt.hook runs in the new worktree directory" {
+@test "hooks: wt.addhook runs in the new worktree directory" {
 	init_bare_repo_with_remote myrepo
 	cd myrepo
-	command git config --add wt.hook 'pwd > .hook-pwd'
+	command git config --add wt.addhook 'pwd > .hook-pwd'
 
 	"$GIT_WT" add -b hook-dir hook-dir
 	local hook_pwd
@@ -33,11 +33,11 @@ teardown() {
 	[ "$hook_pwd" = "$TEST_DIR/myrepo/hook-dir" ]
 }
 
-@test "hooks: multiple wt.hook values run sequentially" {
+@test "hooks: multiple wt.addhook values run sequentially" {
 	init_bare_repo_with_remote myrepo
 	cd myrepo
-	command git config --add wt.hook 'echo first >> .hook-order'
-	command git config --add wt.hook 'echo second >> .hook-order'
+	command git config --add wt.addhook 'echo first >> .hook-order'
+	command git config --add wt.addhook 'echo second >> .hook-order'
 
 	"$GIT_WT" add -b multi-hook multi-hook
 
@@ -49,11 +49,11 @@ teardown() {
 	[ "$(head -1 "$TEST_DIR/myrepo/multi-hook/.hook-order")" = "first" ]
 }
 
-@test "hooks: wt.hook failure stops execution and returns error" {
+@test "hooks: wt.addhook failure stops execution and returns error" {
 	init_bare_repo_with_remote myrepo
 	cd myrepo
-	command git config --add wt.hook 'exit 1'
-	command git config --add wt.hook 'touch .second-ran'
+	command git config --add wt.addhook 'exit 1'
+	command git config --add wt.addhook 'touch .second-ran'
 
 	run "$GIT_WT" add -b fail-hook fail-hook
 	[ "$status" -ne 0 ]
@@ -61,7 +61,27 @@ teardown() {
 	[ ! -f "$TEST_DIR/myrepo/fail-hook/.second-ran" ]
 }
 
-@test "hooks: wt.hook does not run when no hooks configured" {
+@test "hooks: wt.addhook failure does not print success path to stdout" {
+	init_bare_repo_with_remote myrepo
+	cd myrepo
+	command git config --add wt.addhook 'exit 1'
+
+	local stdout_file stderr_file
+	stdout_file="$TEST_DIR/stdout.txt"
+	stderr_file="$TEST_DIR/stderr.txt"
+
+	run bash -c '"$1" add -b fail-stdout fail-stdout >"$2" 2>"$3"' _ \
+		"$GIT_WT" "$stdout_file" "$stderr_file"
+
+	[ "$status" -ne 0 ]
+	# stdout must stay empty on failure (no machine-readable path).
+	[ ! -s "$stdout_file" ]
+	[[ "$(cat "$stdout_file")" != *"fail-stdout"* ]]
+	# The recovery hint with the path goes to stderr instead.
+	[[ "$(cat "$stderr_file")" == *"$TEST_DIR/myrepo/fail-stdout"* ]]
+}
+
+@test "hooks: wt.addhook does not run when no hooks configured" {
 	init_bare_repo_with_remote myrepo
 	cd myrepo
 
@@ -70,10 +90,10 @@ teardown() {
 	assert_worktree_exists "$TEST_DIR/myrepo/no-hook"
 }
 
-@test "hooks: wt.hook output goes to stderr" {
+@test "hooks: wt.addhook output goes to stderr" {
 	init_bare_repo_with_remote myrepo
 	cd myrepo
-	command git config --add wt.hook 'echo hook-output'
+	command git config --add wt.addhook 'echo hook-output'
 
 	local stdout_file stderr_file
 	stdout_file="$TEST_DIR/stdout.txt"
@@ -87,10 +107,23 @@ teardown() {
 	[[ "$(cat "$stderr_file")" == *"hook-output"* ]]
 }
 
-@test "hooks: wt.hook runs in interactive mode" {
+@test "hooks: wt.addhook is echoed, not executed, under DEBUG=1" {
 	init_bare_repo_with_remote myrepo
 	cd myrepo
-	command git config --add wt.hook 'touch .hook-ran'
+	command git config --add wt.addhook 'touch .should-not-run'
+
+	run env DEBUG=1 "$GIT_WT" add -b dbg-hook dbg-hook
+	[ "$status" -eq 0 ]
+	# The hook is echoed rather than run.
+	[[ "$output" == *"sh -c touch .should-not-run"* ]]
+	# DEBUG echoes git mutations too, so nothing should have actually run.
+	[ ! -f "$TEST_DIR/myrepo/dbg-hook/.should-not-run" ]
+}
+
+@test "hooks: wt.addhook runs in interactive mode" {
+	init_bare_repo_with_remote myrepo
+	cd myrepo
+	command git config --add wt.addhook 'touch .hook-ran'
 	command git checkout -b interactive-hook --quiet
 	create_commit "interactive-hook.txt"
 	command git push --quiet -u origin interactive-hook
@@ -102,13 +135,13 @@ teardown() {
 	[ -f "$TEST_DIR/myrepo/interactive-hook/.hook-ran" ]
 }
 
-# --- Delete hooks (wt.deletehook) ---
+# --- Delete hooks (wt.removehook) ---
 
-@test "hooks: wt.deletehook runs before removing worktree" {
+@test "hooks: wt.removehook runs before removing worktree" {
 	init_bare_repo myrepo
 	cd myrepo
 	create_worktree del-hook del-hook
-	command git config --add wt.deletehook 'touch "$TEST_DIR/delete-hook-ran"'
+	command git config --add wt.removehook 'touch "$TEST_DIR/delete-hook-ran"'
 
 	run bash -c 'printf "y\n" | "$1" remove "$2"' _ "$GIT_WT" "$TEST_DIR/myrepo/del-hook"
 	[ "$status" -eq 0 ]
@@ -116,11 +149,11 @@ teardown() {
 	assert_worktree_not_exists "$TEST_DIR/myrepo/del-hook"
 }
 
-@test "hooks: wt.deletehook runs in the worktree directory" {
+@test "hooks: wt.removehook runs in the worktree directory" {
 	init_bare_repo myrepo
 	cd myrepo
 	create_worktree del-dir del-dir
-	command git config --add wt.deletehook 'pwd > "$TEST_DIR/delete-hook-pwd"'
+	command git config --add wt.removehook 'pwd > "$TEST_DIR/delete-hook-pwd"'
 
 	run bash -c 'printf "y\n" | "$1" remove "$2"' _ "$GIT_WT" "$TEST_DIR/myrepo/del-dir"
 	[ "$status" -eq 0 ]
@@ -129,23 +162,23 @@ teardown() {
 	[ "$hook_pwd" = "$TEST_DIR/myrepo/del-dir" ]
 }
 
-@test "hooks: wt.deletehook failure prevents worktree removal" {
+@test "hooks: wt.removehook failure prevents worktree removal" {
 	init_bare_repo myrepo
 	cd myrepo
 	create_worktree del-fail del-fail
-	command git config --add wt.deletehook 'exit 1'
+	command git config --add wt.removehook 'exit 1'
 
 	run bash -c 'printf "y\n" | "$1" remove "$2"' _ "$GIT_WT" "$TEST_DIR/myrepo/del-fail"
 	[ "$status" -ne 0 ]
 	assert_worktree_exists "$TEST_DIR/myrepo/del-fail"
 }
 
-@test "hooks: multiple wt.deletehook values run sequentially" {
+@test "hooks: multiple wt.removehook values run sequentially" {
 	init_bare_repo myrepo
 	cd myrepo
 	create_worktree del-multi del-multi
-	command git config --add wt.deletehook 'echo first >> "$TEST_DIR/del-hook-order"'
-	command git config --add wt.deletehook 'echo second >> "$TEST_DIR/del-hook-order"'
+	command git config --add wt.removehook 'echo first >> "$TEST_DIR/del-hook-order"'
+	command git config --add wt.removehook 'echo second >> "$TEST_DIR/del-hook-order"'
 
 	run bash -c 'printf "y\n" | "$1" remove "$2"' _ "$GIT_WT" "$TEST_DIR/myrepo/del-multi"
 	[ "$status" -eq 0 ]
@@ -153,11 +186,11 @@ teardown() {
 	[ "$(tail -1 "$TEST_DIR/del-hook-order")" = "second" ]
 }
 
-@test "hooks: wt.deletehook does not run for stale prune" {
+@test "hooks: wt.removehook does not run for stale prune" {
 	init_bare_repo myrepo
 	cd myrepo
 	create_worktree stale-prune stale-prune
-	command git config --add wt.deletehook 'touch "$TEST_DIR/prune-hook-ran"'
+	command git config --add wt.removehook 'touch "$TEST_DIR/prune-hook-ran"'
 
 	# Manually remove the worktree directory to make it stale
 	rm -rf "$TEST_DIR/myrepo/stale-prune"
@@ -165,4 +198,19 @@ teardown() {
 	run "$GIT_WT" remove --stale
 	# Hook should NOT have run (prune path doesn't call removeSingleWorktree)
 	[ ! -f "$TEST_DIR/prune-hook-ran" ]
+}
+
+@test "hooks: wt.removehook does not run when removing current worktree is rejected" {
+	init_bare_repo myrepo
+	cd myrepo
+	create_worktree del-current del-current
+	command git config --add wt.removehook 'touch "$TEST_DIR/remove-hook-should-not-run"'
+
+	# Removing the worktree we are standing in is rejected before hooks run.
+	cd "$TEST_DIR/myrepo/del-current"
+	run bash -c 'printf "y\n" | "$1" remove "$2"' _ "$GIT_WT" "$TEST_DIR/myrepo/del-current"
+
+	[ "$status" -ne 0 ]
+	[ ! -f "$TEST_DIR/remove-hook-should-not-run" ]
+	assert_worktree_exists "$TEST_DIR/myrepo/del-current"
 }


### PR DESCRIPTION
This git-wt tool I love a lot more than https://github.com/k1LoW/git-wt but I do want to be able to configure hooks for worktrees. Port that functionality over - allow the ability to configure hooks that are run when a worktree is cloned.

We use this to do things that are very very expensive on new worktrees, like maybe compying compile_commands.json over from a main branch.