### PR TITLE
fix: use path: fetcher in .envrc to work in relative worktrees

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,4 @@
-use flake
+# `path:.` avoids Nix's libgit2 fetcher, which cannot read repos that use
+# extensions.relativeWorktrees — the layout `git wt migrate`/`clone` creates
+# (NixOS/nix#14987; fixed upstream but not yet in a Nix release).
+use flake path:.


### PR DESCRIPTION
Fixes #24.

`use flake` makes Nix fetch the repo via `git+file://` with bundled libgit2, which cannot read `extensions.relativeWorktrees` — the extension `git wt migrate`/`clone` write (git 2.48+). In any migrated repo, `direnv allow` fails:

```
error: opening Git repository "...": unsupported extension name extensions.relativeworktrees (libgit2 error code = 6)
```

The `path:` fetcher copies the tree without consulting git, so the dev shell loads.

Nix fixed this upstream by bumping libgit2 to 1.9.4 (NixOS/nix#14987), but no released Nix carries it yet; this keeps the dev environment working until then. Trade-off: `path:.` includes untracked files in the store copy — harmless for a dev shell.

Verified in a migrated worktree: `nix flake metadata path:.` and `nix develop path:. --command go version` succeed where `git+file://` fails.