### PR TITLE
feat(init): add shell integration for automatic directory changing

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@ can rely on it. The script also defines a thin `git()` wrapper so the
 `eval "$(git-wt init zsh --no-git-wrapper)"` and invoke `git-wt switch`
 instead.
 
+Known limitation: the wrapper keys on the first argument, so global git
+flags before the subcommand (e.g. `git -C <path> wt switch`) bypass it
+and print the path instead of changing directory.
+
 ### Remove a worktree and local branch
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -176,6 +176,29 @@ git wt add --quiet -b feature feature
 cd "$(git wt switch)"
 ```
 
+### Shell integration (automatic cd)
+
+A subprocess can never change its parent shell's directory, so by default
+`switch` and `add` print the worktree path. The `init` command emits a small
+shell script that wraps the binary and runs the `cd` for you:
+
+```bash
+# bash (~/.bashrc)
+eval "$(git-wt init bash)"
+
+# zsh (~/.zshrc)
+eval "$(git-wt init zsh)"
+
+# fish (~/.config/fish/config.fish)
+git-wt init fish | source
+```
+
+After sourcing, `git wt switch` and `git wt add` change directory directly.
+The script also defines a thin `git()` wrapper so the `git wt` spelling
+works; if another tool already wraps `git`, use
+`eval "$(git-wt init zsh --no-git-wrapper)"` and invoke `git-wt switch`
+instead.
+
 ### Remove a worktree and local branch
 
 ```bash
@@ -271,6 +294,7 @@ Hooks apply to `git wt add` and `git wt remove`; the initial worktree created by
 | `remove` / `rm`     | Remove worktrees directly or by safe cleanup filters       |
 | `doctor`            | Run repository diagnostics                                 |
 | `agent-skill`       | Install the git-wt agent skill                             |
+| `init <shell>`      | Print shell integration for automatic directory switching  |
 | `status`            | Show a compact dashboard for linked worktrees              |
 | `list`              | List worktrees with table, JSON, or passthrough Git output |
 | `switch`            | Interactively select a worktree                            |

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ cd "$(git wt switch)"
 ### Shell integration (automatic cd)
 
 A subprocess can never change its parent shell's directory, so by default
-`switch` and `add` print the worktree path. The `init` command emits a small
+`switch` prints the worktree path. The `init` command emits a small
 shell script that wraps the binary and runs the `cd` for you:
 
 ```bash
@@ -193,9 +193,11 @@ eval "$(git-wt init zsh)"
 git-wt init fish | source
 ```
 
-After sourcing, `git wt switch` and `git wt add` change directory directly.
-The script also defines a thin `git()` wrapper so the `git wt` spelling
-works; if another tool already wraps `git`, use
+After sourcing, `git wt switch` changes directory directly. Only `switch`
+is intercepted: `add` keeps printing the created worktree path to stdout
+so scripts and hooks (like the Claude Code `WorktreeCreate` hook below)
+can rely on it. The script also defines a thin `git()` wrapper so the
+`git wt` spelling works; if another tool already wraps `git`, use
 `eval "$(git-wt init zsh --no-git-wrapper)"` and invoke `git-wt switch`
 instead.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,10 @@ git wt add
 # Switch between worktrees
 cd "$(git wt switch)"
 
+# Or source the shell integration once (bash/zsh/fish) so
+# `git wt switch` changes directory by itself
+eval "$(git-wt init zsh)"
+
 # Show repository health
 git wt doctor
 
@@ -132,6 +136,7 @@ Hooks apply to `git wt add` and `git wt remove`; the initial worktree created by
 | `remove [worktree]` | Remove worktrees directly or by safe cleanup filters       |
 | `doctor`            | Run repository diagnostics                                 |
 | `agent-skill`       | Install the git-wt agent skill                             |
+| `init <shell>`      | Print shell integration for automatic directory switching  |
 | `status`            | Show a compact dashboard for linked worktrees              |
 | `list`              | List worktrees with table, JSON, or passthrough Git output |
 | `switch`            | Interactive worktree selection                             |

--- a/internal/cmd/initcmd.go
+++ b/internal/cmd/initcmd.go
@@ -9,13 +9,15 @@ import (
 )
 
 // posixIntegration is shared by bash and zsh. It defines a git-wt function
-// that shadows the binary so switch/add can change the current shell's
+// that shadows the binary so switch can change the current shell's
 // directory, plus an optional git() wrapper so `git wt` reaches the function.
+// Only switch is intercepted: add's stdout (the created worktree path) is a
+// contract that scripts and the Claude Code WorktreeCreate hook rely on.
 const posixIntegration = `# git-wt shell integration
-# Wraps git-wt so 'switch' and 'add' change directory in the current shell.
+# Wraps git-wt so 'switch' changes directory in the current shell.
 git-wt() {
 	case "$1" in
-	switch | add)
+	switch)
 		local dir
 		dir="$(command git-wt "$@")" || return $?
 		if [ -n "$dir" ] && [ -d "$dir" ]; then
@@ -45,9 +47,9 @@ git() {
 `
 
 const fishIntegration = `# git-wt shell integration
-# Wraps git-wt so 'switch' and 'add' change directory in the current shell.
+# Wraps git-wt so 'switch' changes directory in the current shell.
 function git-wt --wraps git-wt
-    if contains -- "$argv[1]" switch add
+    if test "$argv[1]" = switch
         set -l dir (command git-wt $argv)
         set -l code $status
         test $code -ne 0; and return $code
@@ -79,8 +81,11 @@ var initNoGitWrapper bool
 var initCmd = &cobra.Command{
 	Use:   "init [bash|zsh|fish]",
 	Short: "Print shell integration for automatic directory switching",
-	Long: `Print a shell script that makes 'git wt switch' and 'git wt add' change
-the current shell's directory instead of printing a path.
+	Long: `Print a shell script that makes 'git wt switch' change the current
+shell's directory instead of printing a path.
+
+Only switch is intercepted; add keeps printing the created worktree path
+to stdout so scripts and hooks can rely on it.
 
 A subprocess can never change its parent shell's working directory, so the
 script defines a git-wt shell function (and a thin git wrapper) that runs

--- a/internal/cmd/initcmd.go
+++ b/internal/cmd/initcmd.go
@@ -1,0 +1,141 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// posixIntegration is shared by bash and zsh. It defines a git-wt function
+// that shadows the binary so switch/add can change the current shell's
+// directory, plus an optional git() wrapper so `git wt` reaches the function.
+const posixIntegration = `# git-wt shell integration
+# Wraps git-wt so 'switch' and 'add' change directory in the current shell.
+git-wt() {
+	case "$1" in
+	switch | add)
+		local dir
+		dir="$(command git-wt "$@")" || return $?
+		if [ -n "$dir" ] && [ -d "$dir" ]; then
+			cd "$dir" || return 1
+		elif [ -n "$dir" ]; then
+			printf '%s\n' "$dir"
+		fi
+		;;
+	*)
+		command git-wt "$@"
+		;;
+	esac
+}
+`
+
+const posixGitWrapper = `
+# Route 'git wt ...' through the git-wt function above so it can cd too.
+# All other git commands pass through unchanged.
+git() {
+	if [ "$1" = "wt" ]; then
+		shift
+		git-wt "$@"
+	else
+		command git "$@"
+	fi
+}
+`
+
+const fishIntegration = `# git-wt shell integration
+# Wraps git-wt so 'switch' and 'add' change directory in the current shell.
+function git-wt --wraps git-wt
+    if contains -- "$argv[1]" switch add
+        set -l dir (command git-wt $argv)
+        set -l code $status
+        test $code -ne 0; and return $code
+        if test -n "$dir" -a -d "$dir"
+            cd $dir
+        else if test -n "$dir"
+            printf '%s\n' $dir
+        end
+    else
+        command git-wt $argv
+    end
+end
+`
+
+const fishGitWrapper = `
+# Route 'git wt ...' through the git-wt function above so it can cd too.
+# All other git commands pass through unchanged.
+function git --wraps git
+    if test "$argv[1]" = wt
+        git-wt $argv[2..]
+    else
+        command git $argv
+    end
+end
+`
+
+var initNoGitWrapper bool
+
+var initCmd = &cobra.Command{
+	Use:   "init [bash|zsh|fish]",
+	Short: "Print shell integration for automatic directory switching",
+	Long: `Print a shell script that makes 'git wt switch' and 'git wt add' change
+the current shell's directory instead of printing a path.
+
+A subprocess can never change its parent shell's working directory, so the
+script defines a git-wt shell function (and a thin git wrapper) that runs
+the real binary and cd's to the path it prints.
+
+Add to your shell config:
+
+  bash (~/.bashrc):
+    eval "$(git-wt init bash)"
+
+  zsh (~/.zshrc):
+    eval "$(git-wt init zsh)"
+
+  fish (~/.config/fish/config.fish):
+    git-wt init fish | source
+
+Use --no-git-wrapper to skip the git() wrapper if another tool already
+wraps the git command; 'git-wt switch' will still cd, while 'git wt switch'
+keeps printing the path.`,
+	Example:       `  eval "$(git-wt init zsh)"`,
+	Args:          cobra.ExactArgs(1),
+	ValidArgs:     []string{"bash", "zsh", "fish"},
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runInit(os.Stdout, args[0], !initNoGitWrapper)
+	},
+}
+
+func runInit(w io.Writer, shell string, withGitWrapper bool) error {
+	var integration, gitWrapper string
+
+	switch shell {
+	case "bash", "zsh":
+		integration = posixIntegration
+		gitWrapper = posixGitWrapper
+	case "fish":
+		integration = fishIntegration
+		gitWrapper = fishGitWrapper
+	default:
+		return fmt.Errorf("unsupported shell: %s (supported: bash, zsh, fish)", shell)
+	}
+
+	if _, err := io.WriteString(w, integration); err != nil {
+		return err
+	}
+	if withGitWrapper {
+		if _, err := io.WriteString(w, gitWrapper); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func init() {
+	initCmd.Flags().BoolVar(&initNoGitWrapper, "no-git-wrapper", false, "omit the git() wrapper function (only wrap the git-wt command)")
+	rootCmd.AddCommand(initCmd)
+}

--- a/internal/cmd/initcmd_test.go
+++ b/internal/cmd/initcmd_test.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRunInitSupportedShells(t *testing.T) {
+	for _, shell := range []string{"bash", "zsh", "fish"} {
+		t.Run(shell, func(t *testing.T) {
+			var sb strings.Builder
+			if err := runInit(&sb, shell, true); err != nil {
+				t.Fatalf("runInit(%q) returned error: %v", shell, err)
+			}
+			out := sb.String()
+			for _, want := range []string{"git-wt", "switch", "add", "cd "} {
+				if !strings.Contains(out, want) {
+					t.Errorf("runInit(%q) output missing %q", shell, want)
+				}
+			}
+		})
+	}
+}
+
+func TestRunInitGitWrapper(t *testing.T) {
+	for _, shell := range []string{"bash", "fish"} {
+		var with, without strings.Builder
+		if err := runInit(&with, shell, true); err != nil {
+			t.Fatalf("runInit(%q, true) returned error: %v", shell, err)
+		}
+		if err := runInit(&without, shell, false); err != nil {
+			t.Fatalf("runInit(%q, false) returned error: %v", shell, err)
+		}
+		if !strings.Contains(with.String(), "command git ") {
+			t.Errorf("runInit(%q, true) output missing git() wrapper", shell)
+		}
+		if strings.Contains(without.String(), "command git $argv\n    end\nend") && shell == "fish" {
+			t.Errorf("runInit(%q, false) output should omit git() wrapper", shell)
+		}
+		if len(without.String()) >= len(with.String()) {
+			t.Errorf("runInit(%q, false) output should be shorter than with wrapper", shell)
+		}
+	}
+}
+
+func TestRunInitUnsupportedShell(t *testing.T) {
+	var sb strings.Builder
+	err := runInit(&sb, "powershell", true)
+	if err == nil {
+		t.Fatal("runInit(\"powershell\") expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported shell") {
+		t.Errorf("error %q should mention unsupported shell", err)
+	}
+}

--- a/internal/cmd/initcmd_test.go
+++ b/internal/cmd/initcmd_test.go
@@ -13,10 +13,13 @@ func TestRunInitSupportedShells(t *testing.T) {
 				t.Fatalf("runInit(%q) returned error: %v", shell, err)
 			}
 			out := sb.String()
-			for _, want := range []string{"git-wt", "switch", "add", "cd "} {
+			for _, want := range []string{"git-wt", "switch", "cd "} {
 				if !strings.Contains(out, want) {
 					t.Errorf("runInit(%q) output missing %q", shell, want)
 				}
+			}
+			if strings.Contains(out, "add") {
+				t.Errorf("runInit(%q) output should not intercept add", shell)
 			}
 		})
 	}
@@ -34,7 +37,11 @@ func TestRunInitGitWrapper(t *testing.T) {
 		if !strings.Contains(with.String(), "command git ") {
 			t.Errorf("runInit(%q, true) output missing git() wrapper", shell)
 		}
-		if strings.Contains(without.String(), "command git $argv\n    end\nend") && shell == "fish" {
+		gitFunc := "\ngit() {"
+		if shell == "fish" {
+			gitFunc = "function git "
+		}
+		if strings.Contains(without.String(), gitFunc) {
 			t.Errorf("runInit(%q, false) output should omit git() wrapper", shell)
 		}
 		if len(without.String()) >= len(with.String()) {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -20,7 +20,7 @@ const (
 
 var (
 	configureRootCommandOnce sync.Once
-	supportedCommandNames    = []string{"add", "agent-skill", "clone", "doctor", "migrate", "remove", "status", "switch", "update"}
+	supportedCommandNames    = []string{"add", "agent-skill", "clone", "doctor", "init", "migrate", "remove", "status", "switch", "update"}
 	passthroughCommandNames  = []string{"list", "lock", "unlock", "move", "prune", "repair"}
 )
 

--- a/tests/init.bats
+++ b/tests/init.bats
@@ -50,9 +50,10 @@ teardown() {
 	[ "$status" -ne 0 ]
 }
 
-@test "init: sourced bash integration cds on add" {
+@test "init: sourced bash integration cds on switch" {
 	init_bare_repo myrepo
 	cd myrepo
+	create_worktree feature-x feature-x
 
 	# Make the binary under test reachable as `git-wt` for the wrapper
 	mkdir -p "$TEST_DIR/bin"
@@ -61,11 +62,26 @@ teardown() {
 
 	eval "$("$GIT_WT" init bash)"
 
-	git-wt add --quiet -b feature-x feature-x </dev/null
+	GIT_WT_SELECT="$TEST_DIR/myrepo/feature-x" git-wt switch </dev/null
 	[ "$PWD" = "$TEST_DIR/myrepo/feature-x" ]
 }
 
-@test "init: sourced git() wrapper routes git wt add and cds" {
+@test "init: sourced git() wrapper routes git wt switch and cds" {
+	init_bare_repo myrepo
+	cd myrepo
+	create_worktree feature-y feature-y
+
+	mkdir -p "$TEST_DIR/bin"
+	ln -s "$GIT_WT" "$TEST_DIR/bin/git-wt"
+	PATH="$TEST_DIR/bin:$PATH"
+
+	eval "$("$GIT_WT" init bash)"
+
+	GIT_WT_SELECT="$TEST_DIR/myrepo/feature-y" git wt switch </dev/null
+	[ "$PWD" = "$TEST_DIR/myrepo/feature-y" ]
+}
+
+@test "init: sourced integration leaves add scriptable" {
 	init_bare_repo myrepo
 	cd myrepo
 
@@ -75,8 +91,10 @@ teardown() {
 
 	eval "$("$GIT_WT" init bash)"
 
-	git wt add --quiet -b feature-y feature-y </dev/null
-	[ "$PWD" = "$TEST_DIR/myrepo/feature-y" ]
+	local path
+	path="$(git wt add --quiet -b feature-z feature-z </dev/null)"
+	[ "$path" = "$TEST_DIR/myrepo/feature-z" ]
+	[ "$PWD" = "$TEST_DIR/myrepo" ]
 }
 
 @test "init: sourced wrapper passes other commands through" {

--- a/tests/init.bats
+++ b/tests/init.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+	setup_test_env
+}
+
+teardown() {
+	teardown_test_env
+}
+
+@test "init: prints bash integration" {
+	run "$GIT_WT" init bash
+	[ "$status" -eq 0 ]
+	[[ $output == *"git-wt()"* ]]
+	[[ $output == *"git()"* ]]
+	[[ $output == *"cd "* ]]
+}
+
+@test "init: prints zsh integration" {
+	run "$GIT_WT" init zsh
+	[ "$status" -eq 0 ]
+	[[ $output == *"git-wt()"* ]]
+	[[ $output == *"git()"* ]]
+}
+
+@test "init: prints fish integration" {
+	run "$GIT_WT" init fish
+	[ "$status" -eq 0 ]
+	[[ $output == *"function git-wt"* ]]
+	[[ $output == *"function git "* ]]
+}
+
+@test "init: --no-git-wrapper omits the git() wrapper" {
+	run "$GIT_WT" init bash --no-git-wrapper
+	[ "$status" -eq 0 ]
+	[[ $output == *"git-wt()"* ]]
+	[[ $output != *$'\ngit() {'* ]]
+}
+
+@test "init: rejects unsupported shell" {
+	run "$GIT_WT" init powershell
+	[ "$status" -ne 0 ]
+	[[ $output == *"unsupported shell"* ]]
+}
+
+@test "init: requires a shell argument" {
+	run "$GIT_WT" init
+	[ "$status" -ne 0 ]
+}
+
+@test "init: sourced bash integration cds on add" {
+	init_bare_repo myrepo
+	cd myrepo
+
+	# Make the binary under test reachable as `git-wt` for the wrapper
+	mkdir -p "$TEST_DIR/bin"
+	ln -s "$GIT_WT" "$TEST_DIR/bin/git-wt"
+	PATH="$TEST_DIR/bin:$PATH"
+
+	eval "$("$GIT_WT" init bash)"
+
+	git-wt add --quiet -b feature-x feature-x </dev/null
+	[ "$PWD" = "$TEST_DIR/myrepo/feature-x" ]
+}
+
+@test "init: sourced git() wrapper routes git wt add and cds" {
+	init_bare_repo myrepo
+	cd myrepo
+
+	mkdir -p "$TEST_DIR/bin"
+	ln -s "$GIT_WT" "$TEST_DIR/bin/git-wt"
+	PATH="$TEST_DIR/bin:$PATH"
+
+	eval "$("$GIT_WT" init bash)"
+
+	git wt add --quiet -b feature-y feature-y </dev/null
+	[ "$PWD" = "$TEST_DIR/myrepo/feature-y" ]
+}
+
+@test "init: sourced wrapper passes other commands through" {
+	init_bare_repo myrepo
+	cd myrepo
+
+	mkdir -p "$TEST_DIR/bin"
+	ln -s "$GIT_WT" "$TEST_DIR/bin/git-wt"
+	PATH="$TEST_DIR/bin:$PATH"
+
+	eval "$("$GIT_WT" init bash)"
+
+	run git-wt list
+	[ "$status" -eq 0 ]
+	[[ $output == *"main"* ]]
+
+	run git status
+	[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #1.

Implements option 1 (shell integration), with the script emitted by the binary itself rather than shipped as static files — `git wt init [bash|zsh|fish]` prints the integration script, and users add one line to their shell config (the zoxide/direnv/starship pattern):

```bash
# bash (~/.bashrc)
eval "$(git-wt init bash)"

# zsh (~/.zshrc)
eval "$(git-wt init zsh)"

# fish (~/.config/fish/config.fish)
git-wt init fish | source
```

## What the script defines

- **`git-wt()` function** — shadows the binary; for `switch` and `add` it captures stdout and `cd`s to the printed path, everything else passes through. Since both commands print only the worktree path to stdout (hints and spinners already go to stderr), the capture is direct — no last-line heuristics.
- **Thin `git()` wrapper** — routes `git wt ...` to the function above so the natural `git wt switch` spelling changes directory too. `--no-git-wrapper` omits it for users whose `git` is already wrapped by another tool; `git-wt switch` still cds in that case.

## Design notes

- Emitting from the binary keeps packaging unchanged (no new files for Homebrew/Nix to install) and mirrors how the existing `completion` command works.
- The wrapper approach is adapted from [k1LoW/git-wt](https://github.com/k1LoW/git-wt)'s `--init` command (MIT), simplified: no nocd config modes, and intercepting only `switch`/`add`. The `--no-git-wrapper` escape hatch addresses the git-wrapper conflict their README warns about.
- Shell support matches the existing completions (bash/zsh/fish); no powershell.

## Testing

- Go unit tests for the emitter (supported shells, wrapper flag, error case)
- 9 bats E2E tests in `tests/init.bats`, including functional ones that source the bash output and assert the shell actually lands in the new worktree after `git wt add` / `git-wt add`
- Manually verified end-to-end in zsh
- **fish template is untested functionally** (no fish locally) — output shape is covered by bats, but a fish user should give it a spin before merge

Full suite: `go test ./...` green, 151/151 bats pass, prettier clean.

---

**Maintainer update (2026-07-28):** follow-up commits pushed to this branch address the review: the integration now intercepts **only `switch`** — `add` keeps printing the created worktree path to stdout, since scripts and the Claude Code `WorktreeCreate` hook rely on that contract. The branch is also rebased onto `main`, the `git -C <path> wt switch` limitation is documented in the README, and the docs site mirrors the new command. See the comment below for details.
