### PR TITLE
fix: make tables responsive in narrow terminals

### DIFF
--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -232,7 +232,7 @@ func runAddDirect(cmd *cobra.Command, args []string, remote string) (string, err
 			}
 		} else {
 			fmt.Fprintln(os.Stderr)
-			fmt.Fprintln(os.Stderr, renderCommandHintsSection([]commandHint{{
+			fmt.Fprintln(os.Stderr, renderCommandHintsSectionFor(os.Stderr, []commandHint{{
 				Action:  fmt.Sprintf("Push %s and set upstream", ui.Accent(trackBranch)),
 				Command: "git push -u " + remote + " " + trackBranch,
 			}}))

--- a/internal/cmd/render.go
+++ b/internal/cmd/render.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -14,11 +15,19 @@ type commandHint struct {
 }
 
 func renderTableSection(columns []ui.TableColumn, rows [][]string, notes []string, summary string) string {
-	return renderTableSectionWithFooter(columns, rows, notes, summary, "")
+	return renderTableSectionFor(os.Stdout, columns, rows, notes, summary)
+}
+
+func renderTableSectionFor(output *os.File, columns []ui.TableColumn, rows [][]string, notes []string, summary string) string {
+	return renderTableSectionWithFooterFor(output, columns, rows, notes, summary, "")
 }
 
 func renderTableSectionWithFooter(columns []ui.TableColumn, rows [][]string, notes []string, summary string, footer string) string {
-	parts := []string{ui.RenderTable(columns, rows)}
+	return renderTableSectionWithFooterFor(os.Stdout, columns, rows, notes, summary, footer)
+}
+
+func renderTableSectionWithFooterFor(output *os.File, columns []ui.TableColumn, rows [][]string, notes []string, summary string, footer string) string {
+	parts := []string{ui.RenderTableFor(output, columns, rows)}
 	if len(notes) > 0 {
 		parts = append(parts, "", strings.Join(notes, "\n"))
 	}
@@ -28,7 +37,7 @@ func renderTableSectionWithFooter(columns []ui.TableColumn, rows [][]string, not
 	if strings.TrimSpace(footer) != "" {
 		parts = append(parts, "", footer)
 	}
-	return ui.Section("", parts...)
+	return ui.SectionFor(output, "", parts...)
 }
 
 func renderRepoLayoutSection(rootDir string, branches []treeBranch) string {
@@ -51,12 +60,16 @@ func renderRepoLayoutSection(rootDir string, branches []treeBranch) string {
 }
 
 func renderCommandHintsSection(hints []commandHint) string {
+	return renderCommandHintsSectionFor(os.Stdout, hints)
+}
+
+func renderCommandHintsSectionFor(output *os.File, hints []commandHint) string {
 	rows := make([][]string, 0, len(hints))
 	for _, hint := range hints {
 		rows = append(rows, []string{hint.Action, ui.Muted(hint.Command)})
 	}
 
-	return renderTableSection([]ui.TableColumn{
+	return renderTableSectionFor(output, []ui.TableColumn{
 		{Title: "NEXT", MinWidth: 18, MaxWidth: 28},
 		{Title: "COMMAND", MinWidth: 24},
 	}, rows, nil, "")

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -49,17 +49,36 @@ func Section(title string, body ...string) string {
 	if !outputIsTTY() {
 		return content
 	}
-	return sectionBoxStyle().Render(content)
+
+	style := sectionBoxStyle()
+	if width, _, ok := StdoutSize(); ok {
+		contentWidth := width - style.GetHorizontalFrameSize()
+		if contentWidth <= 0 {
+			return wrapText(content, width)
+		}
+		content = wrapText(content, contentWidth)
+	}
+	return style.Render(content)
 }
 
-// RenderTable renders a static table using lipgloss so ANSI-colored content is
-// measured and truncated correctly.
+// RenderTable renders a responsive static table using lipgloss so ANSI-colored
+// content is measured and truncated correctly. On narrow terminals, columns
+// shrink below their preferred minimums; if even the headers cannot fit, rows
+// are rendered as stacked fields instead.
 func RenderTable(columns []TableColumn, rows [][]string) string {
 	if len(columns) == 0 {
 		return ""
 	}
 
 	widths := tableColumnWidths(columns, rows)
+	if maxWidth, ok := tableContentWidth(); ok {
+		var fits bool
+		widths, fits = fitTableWidths(columns, widths, maxWidth)
+		if !fits {
+			return renderStackedTable(columns, rows, maxWidth)
+		}
+	}
+
 	header := tableLine(columns, widths, func(col int, value string) string {
 		return render(tableHeaderStyle, value)
 	})
@@ -68,6 +87,99 @@ func RenderTable(columns []TableColumn, rows [][]string) string {
 		lines = append(lines, tableLineValues(row, widths, nil))
 	}
 	return strings.Join(lines, "\n")
+}
+
+func tableContentWidth() (int, bool) {
+	width, _, ok := StdoutSize()
+	if !ok {
+		return 0, false
+	}
+	return width - sectionBoxStyle().GetHorizontalFrameSize(), true
+}
+
+func fitTableWidths(columns []TableColumn, preferred []int, maxWidth int) ([]int, bool) {
+	cellSpacing := 3*len(columns) - 1
+	available := maxWidth - cellSpacing
+	if available < len(columns) {
+		return nil, false
+	}
+
+	minimums := make([]int, len(columns))
+	minimumTotal := 0
+	preferredTotal := 0
+	for i, col := range columns {
+		minimums[i] = ansi.StringWidth(col.Title)
+		if minimums[i] < 1 {
+			minimums[i] = 1
+		}
+		if minimums[i] > preferred[i] && preferred[i] > 0 {
+			minimums[i] = preferred[i]
+		}
+		minimumTotal += minimums[i]
+		preferredTotal += preferred[i]
+	}
+	if minimumTotal > available {
+		return nil, false
+	}
+	if preferredTotal <= available {
+		return preferred, true
+	}
+
+	widths := append([]int(nil), minimums...)
+	remaining := available - minimumTotal
+	for remaining > 0 {
+		grew := false
+		for i := range widths {
+			if widths[i] >= preferred[i] {
+				continue
+			}
+			widths[i]++
+			remaining--
+			grew = true
+			if remaining == 0 {
+				break
+			}
+		}
+		if !grew {
+			break
+		}
+	}
+	return widths, true
+}
+
+func renderStackedTable(columns []TableColumn, rows [][]string, maxWidth int) string {
+	lines := make([]string, 0, len(rows)*(len(columns)+1))
+	if len(rows) == 0 {
+		for _, col := range columns {
+			lines = append(lines, render(tableHeaderStyle, col.Title))
+		}
+		return strings.Join(lines, "\n")
+	}
+
+	for rowIndex, row := range rows {
+		if rowIndex > 0 {
+			lines = append(lines, "")
+		}
+		for colIndex, col := range columns {
+			value := ""
+			if colIndex < len(row) {
+				value = row[colIndex]
+			}
+			line := render(tableHeaderStyle, col.Title+":")
+			if value != "" {
+				line += " " + value
+			}
+			lines = append(lines, wrapText(line, maxWidth))
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func wrapText(s string, width int) string {
+	if width <= 0 {
+		return s
+	}
+	return ansi.Wrap(s, width, " /._")
 }
 
 func tableColumnWidths(columns []TableColumn, rows [][]string) []int {

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"os"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -20,8 +21,8 @@ var (
 	tableRuleStyle   = lipgloss.NewStyle().Foreground(subtleColor)
 )
 
-func outputIsTTY() bool {
-	return StdoutTTY()
+func outputIsTTY(output *os.File) bool {
+	return output != nil && isTerminal(output)
 }
 
 func sectionBoxStyle() lipgloss.Style {
@@ -37,41 +38,54 @@ func Title(s string) string {
 	return render(titleStyle, s)
 }
 
-// Section renders a section. The title is optional. On TTYs it adds a border;
-// otherwise it emits simple plain-text output.
+// Section renders a section for stdout. The title is optional. On TTYs it adds
+// a border; otherwise it emits simple plain-text output.
 func Section(title string, body ...string) string {
+	return SectionFor(os.Stdout, title, body...)
+}
+
+// SectionFor renders a section sized for output.
+func SectionFor(output *os.File, title string, body ...string) string {
 	parts := make([]string, 0, len(body)+1)
 	if strings.TrimSpace(title) != "" {
 		parts = append(parts, Title(title))
 	}
 	parts = append(parts, body...)
 	content := strings.Join(parts, "\n")
-	if !outputIsTTY() {
+	if !outputIsTTY(output) {
 		return content
 	}
 
 	style := sectionBoxStyle()
-	if width, _, ok := StdoutSize(); ok {
+	if width, _, ok := TerminalSize(output); ok {
 		contentWidth := width - style.GetHorizontalFrameSize()
 		if contentWidth <= 0 {
 			return wrapText(content, width)
 		}
 		content = wrapText(content, contentWidth)
+		if textExceedsWidth(content, contentWidth) {
+			return wrapText(content, width)
+		}
 	}
 	return style.Render(content)
 }
 
-// RenderTable renders a responsive static table using lipgloss so ANSI-colored
-// content is measured and truncated correctly. On narrow terminals, columns
-// shrink below their preferred minimums; if even the headers cannot fit, rows
-// are rendered as stacked fields instead.
+// RenderTable renders a responsive static table for stdout.
 func RenderTable(columns []TableColumn, rows [][]string) string {
+	return RenderTableFor(os.Stdout, columns, rows)
+}
+
+// RenderTableFor renders a responsive static table sized for output using
+// lipgloss so ANSI-colored content is measured and truncated correctly. On
+// narrow terminals, columns shrink below their preferred minimums; if even the
+// headers cannot fit, rows are rendered as stacked fields instead.
+func RenderTableFor(output *os.File, columns []TableColumn, rows [][]string) string {
 	if len(columns) == 0 {
 		return ""
 	}
 
 	widths := tableColumnWidths(columns, rows)
-	if maxWidth, ok := tableContentWidth(); ok {
+	if maxWidth, ok := tableContentWidth(output); ok {
 		var fits bool
 		widths, fits = fitTableWidths(columns, widths, maxWidth)
 		if !fits {
@@ -89,8 +103,8 @@ func RenderTable(columns []TableColumn, rows [][]string) string {
 	return strings.Join(lines, "\n")
 }
 
-func tableContentWidth() (int, bool) {
-	width, _, ok := StdoutSize()
+func tableContentWidth(output *os.File) (int, bool) {
+	width, _, ok := TerminalSize(output)
 	if !ok {
 		return 0, false
 	}
@@ -179,7 +193,69 @@ func wrapText(s string, width int) string {
 	if width <= 0 {
 		return s
 	}
-	return ansi.Wrap(s, width, " /._")
+
+	wrapped := ansi.Wrap(s, width, " /._")
+	// Wrap can leave a breakpoint one cell past the limit. Hardwrap enforces
+	// the width without changing lines that already fit.
+	wrapped = ansi.Hardwrap(wrapped, width, true)
+	return preserveANSIStylesAcrossLines(wrapped)
+}
+
+func textExceedsWidth(s string, width int) bool {
+	for _, line := range strings.Split(s, "\n") {
+		if ansi.StringWidth(line) > width {
+			return true
+		}
+	}
+	return false
+}
+
+// preserveANSIStylesAcrossLines closes and reopens active SGR styles so the
+// resets Lipgloss adds around each border do not clear wrapped continuations.
+func preserveANSIStylesAcrossLines(s string) string {
+	if !strings.Contains(s, "\n") || !strings.Contains(s, "\x1b[") {
+		return s
+	}
+
+	var result strings.Builder
+	result.Grow(len(s))
+	activeStyles := ""
+	for i := 0; i < len(s); {
+		if s[i] == '\x1b' && i+1 < len(s) && s[i+1] == '[' {
+			end := i + 2
+			for end < len(s) && (s[end] < 0x40 || s[end] > 0x7e) {
+				end++
+			}
+			if end < len(s) {
+				sequence := s[i : end+1]
+				result.WriteString(sequence)
+				if s[end] == 'm' {
+					params := sequence[2 : len(sequence)-1]
+					switch {
+					case params == "" || params == "0":
+						activeStyles = ""
+					case strings.HasPrefix(params, "0;") || strings.HasPrefix(params, "0:"):
+						activeStyles = sequence
+					default:
+						activeStyles += sequence
+					}
+				}
+				i = end + 1
+				continue
+			}
+		}
+
+		if s[i] == '\n' && activeStyles != "" {
+			result.WriteString(ansi.ResetStyle)
+			result.WriteByte('\n')
+			result.WriteString(activeStyles)
+			i++
+			continue
+		}
+		result.WriteByte(s[i])
+		i++
+	}
+	return result.String()
 }
 
 func tableColumnWidths(columns []TableColumn, rows [][]string) []int {

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -704,11 +704,76 @@ func TestRenderTableStacksWhenHeadersCannotFit(t *testing.T) {
 	}
 }
 
+func TestSectionHardWrapsBreakpointAtTerminalWidth(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	mockStdoutTerminalWidth(t, 77)
+
+	got := Section("", "Safe candidates only: merged branches, gone upstreams, and stale metadata.")
+	for i, line := range strings.Split(got, "\n") {
+		if width := ansi.StringWidth(line); width > 77 {
+			t.Fatalf("line %d width = %d, want <= 77: %q", i+1, width, line)
+		}
+	}
+}
+
+func TestSectionOmitsBoxWhenContentCannotFitInterior(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	mockStdoutTerminalWidth(t, 5)
+
+	got := Section("", "🙂")
+	if strings.Contains(got, "╭") {
+		t.Fatalf("Section() should omit a box that cannot fit: %q", got)
+	}
+	if width := ansi.StringWidth(got); width > 5 {
+		t.Fatalf("Section() width = %d, want <= 5: %q", width, got)
+	}
+}
+
+func TestWrapTextPreservesANSIStylesAcrossLines(t *testing.T) {
+	const red = "\x1b[31m"
+	got := wrapText(red+"abcdefghij\x1b[0m", 5)
+	lines := strings.Split(got, "\n")
+	if len(lines) != 2 {
+		t.Fatalf("wrapText() produced %d lines, want 2: %q", len(lines), got)
+	}
+	if !strings.HasSuffix(lines[0], ansi.ResetStyle) {
+		t.Fatalf("wrapText() did not reset style before newline: %q", got)
+	}
+	if !strings.HasPrefix(lines[1], red) {
+		t.Fatalf("wrapText() did not restore style after newline: %q", got)
+	}
+}
+
+func TestTableRenderingUsesDestinationTerminal(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	mockTerminalWidth(t, os.Stderr, 27)
+
+	got := SectionFor(os.Stderr, "", RenderTableFor(
+		os.Stderr,
+		[]TableColumn{{Title: "FIRST"}, {Title: "SECOND"}, {Title: "THIRD"}},
+		[][]string{{"one", "two", "a third value that wraps"}},
+	))
+	plain := ansi.Strip(got)
+	if !strings.Contains(plain, "FIRST: one") {
+		t.Fatalf("RenderTableFor() did not use stderr width: %q", plain)
+	}
+	for i, line := range strings.Split(plain, "\n") {
+		if width := ansi.StringWidth(line); width > 27 {
+			t.Fatalf("line %d width = %d, want <= 27: %q", i+1, width, line)
+		}
+	}
+}
+
 func mockStdoutTerminalWidth(t *testing.T, width int) {
+	t.Helper()
+	mockTerminalWidth(t, os.Stdout, width)
+}
+
+func mockTerminalWidth(t *testing.T, output *os.File, width int) {
 	t.Helper()
 	oldIsTerminal := isTerminal
 	oldGetTerminalSize := getTerminalSize
-	isTerminal = func(f *os.File) bool { return f == os.Stdout }
+	isTerminal = func(f *os.File) bool { return f == output }
 	getTerminalSize = func(f *os.File) (int, int, error) { return width, 24, nil }
 	t.Cleanup(func() {
 		isTerminal = oldIsTerminal

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -649,4 +650,68 @@ func TestRenderTableRespectsMaxWidth(t *testing.T) {
 	if !strings.Contains(plain, "this shou…") {
 		t.Fatalf("RenderTable() should truncate detail column, got %q", plain)
 	}
+}
+
+func TestRenderTableFitsNarrowTerminal(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	mockStdoutTerminalWidth(t, 80)
+
+	got := Section("", RenderTable(
+		[]TableColumn{
+			{Title: "ACTION", MinWidth: 8},
+			{Title: "WORKTREE", MinWidth: 18},
+			{Title: "BRANCH", MinWidth: 14},
+			{Title: "EFFECT", MinWidth: 28},
+			{Title: "REASON", MinWidth: 18, MaxWidth: 64},
+		},
+		[][]string{{
+			"remove",
+			"/a/very/long/worktree/path",
+			"feature-with-a-long-name",
+			"remove and delete the local branch",
+			"selected target with additional context",
+		}},
+	))
+	plain := ansi.Strip(got)
+	if !strings.Contains(plain, "…") {
+		t.Fatalf("RenderTable() should truncate cells to fit a narrow terminal, got %q", plain)
+	}
+	for i, line := range strings.Split(plain, "\n") {
+		if width := ansi.StringWidth(line); width > 80 {
+			t.Fatalf("line %d width = %d, want <= 80: %q", i+1, width, line)
+		}
+	}
+}
+
+func TestRenderTableStacksWhenHeadersCannotFit(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	mockStdoutTerminalWidth(t, 27)
+
+	got := Section("", RenderTable(
+		[]TableColumn{{Title: "FIRST"}, {Title: "SECOND"}, {Title: "THIRD"}},
+		[][]string{{"one", "two", "a third value that wraps"}},
+	))
+	plain := ansi.Strip(got)
+	for _, want := range []string{"FIRST: one", "SECOND: two", "THIRD:"} {
+		if !strings.Contains(plain, want) {
+			t.Fatalf("stacked RenderTable() missing %q in %q", want, plain)
+		}
+	}
+	for i, line := range strings.Split(plain, "\n") {
+		if width := ansi.StringWidth(line); width > 27 {
+			t.Fatalf("line %d width = %d, want <= 27: %q", i+1, width, line)
+		}
+	}
+}
+
+func mockStdoutTerminalWidth(t *testing.T, width int) {
+	t.Helper()
+	oldIsTerminal := isTerminal
+	oldGetTerminalSize := getTerminalSize
+	isTerminal = func(f *os.File) bool { return f == os.Stdout }
+	getTerminalSize = func(f *os.File) (int, int, error) { return width, 24, nil }
+	t.Cleanup(func() {
+		isTerminal = oldIsTerminal
+		getTerminalSize = oldGetTerminalSize
+	})
 }


### PR DESCRIPTION
## Summary

- fit table columns within the detected terminal width
- truncate oversized cells and stack fields when headers cannot fit
- wrap section notes and summaries within box borders
- add coverage for 80-column and extremely narrow terminals

## Testing

- `go test ./...`
- `go vet ./...`
- `staticcheck ./...`
- `bats tests/` — 142 tests
- `nix fmt -- --fail-on-change`

Fixes #29
