### PR TITLE
fix: migrate slash-named branches

### DIFF
--- a/internal/cmd/migrate.go
+++ b/internal/cmd/migrate.go
@@ -471,7 +471,16 @@ func buildMigratedStructure(plan migratePlan, newStructure string) error {
 			// Restore git index (staged changes).
 			oldIndex := filepath.Join(plan.repoRoot, ".git", "index")
 			if _, err := os.Stat(oldIndex); err == nil {
-				newIndex := filepath.Join(newStructure, ".bare", "worktrees", plan.currentBranch, "index")
+				newIndex, err := git.QueryIn(destDir, "rev-parse", "--git-path", "index")
+				if err != nil {
+					return fmt.Errorf("failed to resolve migrated git index: %w", err)
+				}
+				if newIndex == "" {
+					return fmt.Errorf("failed to resolve migrated git index")
+				}
+				if !filepath.IsAbs(newIndex) {
+					newIndex = filepath.Join(destDir, newIndex)
+				}
 				if err := copyFileSimple(oldIndex, newIndex); err != nil {
 					return fmt.Errorf("failed to restore git index: %w", err)
 				}

--- a/internal/cmd/migrate.go
+++ b/internal/cmd/migrate.go
@@ -471,16 +471,13 @@ func buildMigratedStructure(plan migratePlan, newStructure string) error {
 			// Restore git index (staged changes).
 			oldIndex := filepath.Join(plan.repoRoot, ".git", "index")
 			if _, err := os.Stat(oldIndex); err == nil {
-				newIndex, err := git.QueryIn(destDir, "rev-parse", "--git-path", "index")
+				// Resolve the worktree's own index rather than honoring an inherited
+				// GIT_INDEX_FILE, which may point outside the migrated repository.
+				newGitDir, err := git.QueryIn(destDir, "rev-parse", "--absolute-git-dir")
 				if err != nil {
 					return fmt.Errorf("failed to resolve migrated git index: %w", err)
 				}
-				if newIndex == "" {
-					return fmt.Errorf("failed to resolve migrated git index")
-				}
-				if !filepath.IsAbs(newIndex) {
-					newIndex = filepath.Join(destDir, newIndex)
-				}
+				newIndex := filepath.Join(newGitDir, "index")
 				if err := copyFileSimple(oldIndex, newIndex); err != nil {
 					return fmt.Errorf("failed to restore git index: %w", err)
 				}

--- a/tests/migrate.bats
+++ b/tests/migrate.bats
@@ -71,6 +71,25 @@ teardown() {
 	[[ $(cat "$wt_dir/file.txt") == "modified content" ]]
 }
 
+@test "migrate: handles slash-containing current branch names" {
+	init_repo myrepo
+	cd myrepo
+	command git checkout --quiet -b feature/foo
+	create_commit "feature.txt"
+	echo "staged content" > staged.txt
+	command git add staged.txt
+
+	run bash -c 'echo "y" | "$1" migrate 2>&1' _ "$GIT_WT"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"Migration complete"* ]]
+	[ -d "$TEST_DIR/myrepo/feature/foo" ]
+
+	cd "$TEST_DIR/myrepo/feature/foo"
+	[[ $(command git branch --show-current) == "feature/foo" ]]
+	[[ $(command git diff --cached --name-only) == "staged.txt" ]]
+	[[ $(cat staged.txt) == "staged content" ]]
+}
+
 @test "migrate: creates separate worktrees for default and current branch" {
 	init_repo_with_remote myrepo
 	cd myrepo

--- a/tests/migrate.bats
+++ b/tests/migrate.bats
@@ -90,6 +90,21 @@ teardown() {
 	[[ $(cat staged.txt) == "staged content" ]]
 }
 
+@test "migrate: restores the repository index when GIT_INDEX_FILE is set" {
+	init_repo myrepo
+	cd myrepo
+	echo "staged content" > staged.txt
+	command git add staged.txt
+
+	run env GIT_INDEX_FILE="$TEST_DIR/alternate-index" bash -c 'echo "y" | "$1" migrate 2>&1' _ "$GIT_WT"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"Migration complete"* ]]
+
+	cd "$TEST_DIR/myrepo/main"
+	[[ $(command git diff --cached --name-only) == "staged.txt" ]]
+	[[ $(command git show :staged.txt) == "staged content" ]]
+}
+
 @test "migrate: creates separate worktrees for default and current branch" {
 	init_repo_with_remote myrepo
 	cd myrepo


### PR DESCRIPTION
## Summary

- ask git for the migrated worktree's real index path instead of guessing from the branch name
- support relative `--git-path` output before copying the original index
- add migrate regression coverage for current branches like `feature/foo`

Fixes #30.

## Tests

- `go test ./...`
- `bats tests/migrate.bats`
